### PR TITLE
Fix Alpaca discovery dying on AP-mode Wi-Fi when multicast join fails

### DIFF
--- a/AlpacaHTTP/src/discovery/discovery.cpp
+++ b/AlpacaHTTP/src/discovery/discovery.cpp
@@ -72,17 +72,20 @@ void Discovery::run_discovery() {
         return;
     }
 
-    // Join multicast group
+    // Join multicast group. This is optional — the ASCOM Alpaca discovery
+    // protocol primarily uses UDP broadcast to 255.255.255.255:32227, which a
+    // socket bound to INADDR_ANY:32227 already receives. Multicast join can
+    // fail on AP/hotspot interfaces that lack a default multicast route; in
+    // that case we must NOT tear down the listener, or broadcast-based clients
+    // (NINA, PHD2 auto-discover) will see no server.
     struct ip_mreq mreq;
     mreq.imr_multiaddr.s_addr = inet_addr(ALPACA_DISCOVERY_MULTICAST_GROUP);
     mreq.imr_interface.s_addr = INADDR_ANY;
     const char* mreq_ptr = reinterpret_cast<const char*>(&mreq);
     if (setsockopt(socket_fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP, mreq_ptr, sizeof(mreq)) < 0) {
-        util::log_error("Failed to join multicast group");
-        util::socket_close(socket_fd_);
-        socket_fd_ = util::kInvalidSocket;
-        running_ = false;
-        return;
+        util::log_warning("Failed to join Alpaca multicast group " +
+                          std::string(ALPACA_DISCOVERY_MULTICAST_GROUP) +
+                          " (continuing with broadcast/unicast discovery only)");
     }
 
     util::log_info("Discovery service started on port " + std::to_string(ALPACA_DISCOVERY_PORT));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
+## [1.0.4] - UNRELEASED
+
+### Fixed
+- **Alpaca Discovery** (AlpacaHTTP): UDP discovery listener on port 32227 no longer tears itself down when the multicast group join fails. The ASCOM Alpaca discovery protocol primarily uses UDP broadcast to `255.255.255.255:32227` (which a socket bound to `INADDR_ANY:32227` already receives), so multicast-join failure is now logged as a warning and discovery continues serving broadcast/unicast probes. Fixes NINA "Discover Servers" returning zero results when AlpacaBridge runs on an RPi acting as its own Wi-Fi access point (NetworkManager `ipv4.method shared`), where `wlan0` has no default multicast route and `IP_ADD_MEMBERSHIP` fails. Externally-routed LAN setups are unaffected.
+
 ## [1.0.3] - 2026-05-07
 
 ### Added


### PR DESCRIPTION
## Summary
- The UDP discovery listener on port 32227 was tearing itself down whenever `IP_ADD_MEMBERSHIP` failed, leaving Alpaca clients unable to auto-discover the server even though HTTP on 6800 was reachable.
- This reproduced reliably when AlpacaBridge runs on an RPi acting as its own Wi-Fi access point (NetworkManager `ipv4.method shared` on `wlan0`): no default multicast route → join fails → listener closes → NINA's "Discover Servers" returns 0 results.
- Demoted multicast-join failure to a warning so the broadcast/unicast listener stays up. Multicast is optional for the ASCOM Alpaca discovery protocol — clients primarily broadcast to `255.255.255.255:32227`, which an `INADDR_ANY` socket already receives.

## Changes
- **Discovery Service** (AlpacaHTTP): `IP_ADD_MEMBERSHIP` failure no longer closes the UDP socket or kills the discovery thread (`AlpacaHTTP/src/discovery/discovery.cpp`). On failure the multicast group is skipped and the listener continues serving broadcast/unicast probes.
- **CHANGELOG**: Added `[1.0.4] - UNRELEASED` with the Fixed entry.

## Why not change the HTTP port?
There was a parallel discussion about moving HTTP from 6800 to 32227 because clients "expect" 32227. That's a misread of the spec: 32227 is the UDP **discovery** port (already in use by this very service), not the Alpaca HTTP port. The Alpaca spec deliberately leaves the HTTP port open; clients learn it from the discovery reply's `{\"AlpacaPort\": 6800}`. Renumbering wouldn't have fixed anything — discovery itself was dead.

## Test plan
- [x] Builds clean on Linux arm64 (`alpacahttp_server` linked)
- [x] Manual verification on RPi running NetworkManager AP-mode hotspot ("Eric" SSID, `wlan0` 192.168.50.10/24)
  - Before fix: `sudo ss -ulnp | grep 32227` → empty; NINA "Discover Servers" → 0 results
  - After fix: UDP 32227 bound on `0.0.0.0`; NINA auto-discovery populates
- [x] Externally-routed LAN setups (router + eth0) unaffected — multicast join still succeeds there
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UDP discovery to continue operating when multicast group joining fails. Discovery now reliably serves broadcast and unicast probes even when multicast is unavailable, resolving discovery failures on certain network configurations such as Raspberry Pi hotspot setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-astro/AlpacaBridge/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->