### PR TITLE
Add /conformu skill and block commit/PR on failing ConformU reports

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -48,7 +48,49 @@ For each changed file, briefly note what was modified. Group changes by category
 - **Large binary files**: files over 10MB that aren't vendor SDK libraries
 - **Unrelated changes**: files modified that don't belong to this logical change — suggest splitting into separate commits
 
-## Step 3 — Update SUPPORTED-DRIVERS.md (if applicable)
+## Step 3 — Validate ConformU reports (HARD BLOCK)
+
+If any files in this commit (staged or about to be added) live under `AlpacaCore/conformu/`, parse each one and refuse to proceed if it reports failures. This is non-negotiable — committing a failing ConformU log poisons `SUPPORTED-DRIVERS.md` and misleads other contributors into thinking the driver is validated.
+
+### Find ConformU files in scope
+
+```bash
+{ git diff --cached --name-only --diff-filter=AM; \
+  git diff --name-only --diff-filter=AM; \
+  git ls-files -o --exclude-standard; } \
+  | sort -u | grep -E '^AlpacaCore/conformu/.*\.(json|txt)$'
+```
+
+If the list is empty, skip the rest of this step.
+
+### JSON report check (preferred when available)
+
+For each `*.json` in the list (typically `conform.report.json` or `<platform>.report.json`):
+
+```bash
+ERR=$(jq -r '.ErrorCount // 0' <file>)
+ISS=$(jq -r '.IssueCount // 0' <file>)
+TIM=$(jq -r '.TimingIssuesCount // 0' <file>)
+```
+
+**Fail** if any of `ERR`, `ISS`, or `TIM` is non-zero.
+
+### Text log check (always run, even if JSON also exists)
+
+For each `*.txt` in the list, **fail** if any of these are true:
+- `grep -E "OUTSIDE (FAST|STANDARD|EXTENDED) RESPONSE TIME TARGET" <file>` matches → timing issue
+- `grep "took longer than its target response time" <file>` matches → timing issue summary
+- The file does NOT contain `Congratulations, no errors, warnings or issues found` → errors or issues
+
+### On failure — STOP
+
+Refuse to stage, refuse to commit the ConformU files, and tell the user exactly what failed:
+
+> "ConformU report `<file>` failed validation: Errors=N, Issues=N, TimingIssues=N (or matching grep lines). The driver is not validated. Fix the driver, re-run ConformU until clean, replace the report, and try again. See `/driver-build` Step 10 for the full pass criteria."
+
+Do NOT commit. Do NOT offer to commit "anyway" or "as a WIP". This block exists because a passing-looking commit makes future debugging much harder and falsely advertises the driver as validated in `SUPPORTED-DRIVERS.md` updates that follow.
+
+## Step 4 — Update SUPPORTED-DRIVERS.md (if applicable)
 
 If the changes include **driver code**, **ConformU results**, or **new device support**, check whether `SUPPORTED-DRIVERS.md` needs updating:
 
@@ -78,7 +120,7 @@ Driver Notes format:
 - **Tested model**: Model on Linux arm64
 ```
 
-## Step 4 — Update CHANGELOG.md
+## Step 5 — Update CHANGELOG.md
 
 Every commit that changes code or adds features should have a corresponding `CHANGELOG.md` entry. The project uses [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
@@ -119,7 +161,7 @@ Use component-tagged bullet points matching the project style:
 - **Don't duplicate**: if an entry for this driver/feature already exists in UNRELEASED, update it rather than adding a new one
 - If the current UNRELEASED section already has the right version number, add to it — don't create a new one
 
-## Step 5 — Stage the right files
+## Step 6 — Stage the right files
 
 Stage files that belong together in one logical commit. Prefer specific file paths over `git add -A` or `git add .`.
 
@@ -135,7 +177,7 @@ If changes span multiple logical units (e.g., driver code + ConformU results + d
 4. **Documentation** — CHANGELOG, AGENTS.md, SUPPORTED-DRIVERS.md
 5. **SDK addition** — external/ SDK files (often a large commit on its own)
 
-## Step 6 — Write the commit message
+## Step 7 — Write the commit message
 
 Draft a commit message following the project's conventions observed in the git history.
 
@@ -193,7 +235,7 @@ Avoid:
 - Messages that don't say what vendor/device was affected
 - Messages longer than 72 characters on the summary line
 
-## Step 7 — Commit
+## Step 8 — Commit
 
 Present the staged files and draft message to the user for approval. Then commit:
 
@@ -208,7 +250,7 @@ EOF
 
 After committing, run `git status` to confirm the working tree is clean (or show what's left unstaged).
 
-## Step 8 — Follow-up suggestions
+## Step 9 — Follow-up suggestions
 
 After the commit, suggest next steps if appropriate:
 - "There are more unstaged changes — want to commit those separately?"

--- a/.claude/commands/conformu.md
+++ b/.claude/commands/conformu.md
@@ -1,0 +1,398 @@
+---
+description: Run ConformU against a connected AlpacaBridge device, validate the results (errors, issues, timing), save the logs, and update SUPPORTED-DRIVERS.md
+argument-hint: [vendor] [model]
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+You are the ConformU test session assistant for AlpacaBridge. Your job is to drive a single ConformU run against a device that is already configured and connected in a running AlpacaBridge instance, validate the result against the project's strict pass criteria (errors, issues, AND timing), then save the logs and update `SUPPORTED-DRIVERS.md`.
+
+You DO NOT start or stop AlpacaBridge — that is the user's responsibility. You DO NOT connect the device — that is configured via the web UI. You only run ConformU and handle its output.
+
+## How to use arguments
+
+The user invoked this command with: $ARGUMENTS
+
+- If `$ARGUMENTS` includes a vendor and a model (e.g. `iOptron HEM27`), use them as defaults in Step 1 — still confirm with the user.
+- If only a vendor is provided, ask for the model.
+- If no arguments are provided, ask for everything in Step 1.
+
+## Step 1 — Gather session inputs
+
+Ask the following **one at a time**, waiting for each answer before moving on. If `$ARGUMENTS` already covers a value, present it as the default and ask for confirmation rather than re-asking from scratch.
+
+1. **Vendor** — must match an existing vendor directory under `AlpacaCore/conformu/` if one exists. Get the canonical list with:
+   ```bash
+   ls -1 AlpacaCore/conformu/ | grep -v '\.md$'
+   ```
+   Use the existing case exactly (e.g. `Player One`, not `PlayerOne`; `iOptron`, not `IOptron`). If the vendor is new, confirm the canonical name the user wants for the directory.
+
+2. **Model / device name** — the human-readable model (e.g. `HEM27`, `Ceres 462M`, `ASI2600MC Pro`). This becomes the directory name under the vendor. If the vendor already has subdirectories, list them so the user can match the existing naming style.
+
+3. **ASCOM device type** — Camera, CoverCalibrator, Dome, FilterWheel, Focuser, ObservingConditions, Rotator, SafetyMonitor, Switch, Telescope. Needed to build the Alpaca URI path segment (`camera`, `telescope`, etc. — lowercase).
+
+4. **Connection transport** — USB, Wi-Fi, Serial, or TCP. Used as the filename suffix and as the connection cell in `SUPPORTED-DRIVERS.md`. The on-disk suffix is lowercase (`usb`, `wifi`, `serial`, `tcp`). The table cell uses display form (`USB`, `Wi-Fi`, `Serial`, `TCP`).
+   - If the device only supports one transport, omit the suffix — file is `Linux-arm64.txt`.
+   - If the device supports multiple and this run only tests one, use the suffix — file is `Linux-arm64-<transport>.txt`. Existing reports already exist for the same device — those other transports stay untouched.
+
+5. **Alpaca host:port** — defaults to `http://localhost:11111`. Ask if they want a different host (e.g. testing against a remote SBC).
+
+6. **Device number** — defaults to `0`. Most single-device setups stay at 0.
+
+After all answers, summarize and confirm before continuing:
+
+> "Ready to run ConformU against `<vendor> <model>` (<type>) over <transport> at `http://<host>:<port>/api/v1/<type>/<n>`. Output will be saved to `AlpacaCore/conformu/<Vendor>/<Model>/Linux-arm64[-<transport>].txt`. Proceed?"
+
+## Step 2 — Pre-flight checks (HARD STOP if any fail)
+
+Before invoking ConformU, verify the environment. If any check fails, **STOP** and tell the user what to fix. Do NOT run ConformU against a broken setup — it wastes time and produces noisy logs that look like driver bugs.
+
+### 2a. AlpacaBridge reachability
+
+```bash
+curl -sS --max-time 5 http://<host>:<port>/management/v1/description | head -c 500
+```
+
+Expect a JSON response containing `ServerName` or `Manufacturer`. If the request times out or returns an error:
+
+> "AlpacaBridge is not reachable at `http://<host>:<port>`. Start it (`./build_and_run.sh`) and re-run `/conformu`."
+
+### 2b. Device is configured
+
+```bash
+curl -sS --max-time 5 "http://<host>:<port>/api/v1/<type>/<n>/name?ClientID=1&ClientTransactionID=1"
+```
+
+Expect a JSON body with `Value` set to a non-empty string and `ErrorNumber: 0`. If `ErrorNumber` is non-zero or the request 404s, the device isn't configured at that number:
+
+> "No `<type>` device is configured at index `<n>` on `http://<host>:<port>`. Configure it via the web UI (`http://<host>:<port>/`) and re-run."
+
+### 2c. Device is connected
+
+```bash
+curl -sS --max-time 5 "http://<host>:<port>/api/v1/<type>/<n>/connected?ClientID=1&ClientTransactionID=1"
+```
+
+Expect `Value: true`, `ErrorNumber: 0`. If `Value: false`:
+
+> "Device `<vendor> <model>` is configured but not connected. Connect it via the web UI before running ConformU."
+
+If `ErrorNumber` is non-zero (e.g. NotConnected because hardware is unplugged), report the exact error and stop.
+
+### 2d. Capture the current AB log level (so we can restore it later)
+
+```bash
+curl -sS --max-time 5 "http://<host>:<port>/management/v1/loglevel?ClientID=1&ClientTransactionID=1" \
+  | jq -r '.Value | fromjson | .Level'
+```
+
+Save this value (e.g. `INFO`) into a session variable — Step 8 restores it. The log level is persisted on disk, so a crash mid-skill would leave AB at TRACE forever; restoring is mandatory on every exit path including failure.
+
+### 2e. Set AB log level to TRACE
+
+```bash
+curl -sS --max-time 5 -X PUT "http://<host>:<port>/management/v1/loglevel" \
+  -H "Content-Type: application/json" \
+  -d '{"Level":"TRACE","ClientID":1,"ClientTransactionID":1}'
+```
+
+Verify the response shows `Level: TRACE`. TRACE includes every driver call, SDK round-trip, and HTTP request — exactly what we need to diagnose any ConformU failure.
+
+### 2f. Capture the AB log file path and a pre-run baseline timestamp
+
+```bash
+curl -sS --max-time 5 "http://<host>:<port>/management/v1/logfiles?ClientID=1&ClientTransactionID=1" \
+  | jq -r '.Value | fromjson | .Directory'
+```
+
+Save the directory. Today's log file is named per the daily convention (check the Files list in the same response). Record `date -u +%H:%M:%S.%3N` as the **run-start baseline** — used in Step 5 to slice the log to just this test window.
+
+### 2g. ConformU binary is available
+
+Search common locations in this order, stop at the first match:
+```bash
+command -v conformu
+ls /home/dev/Downloads/conformu/conformu
+ls /opt/conformu/conformu
+ls ~/conformu/conformu
+```
+
+If none found:
+
+> "ConformU binary not found. Download from https://github.com/ASCOMInitiative/ConformU/releases (linux-arm64) and extract to `~/conformu/` or `/home/dev/Downloads/conformu/`."
+
+Confirm the version (target 4.3.0 or newer):
+```bash
+<path-to-conformu>/conformu --version
+```
+
+## Step 3 — Run ConformU
+
+Create a temp working directory and invoke the conformance subcommand:
+
+```bash
+TMPDIR=$(mktemp -d /tmp/conformu-XXXXXX)
+<path-to-conformu>/conformu conformance \
+  "http://<host>:<port>/api/v1/<type>/<n>" \
+  -n "$TMPDIR/conformu.txt" \
+  -r "$TMPDIR/conform.report.json"
+```
+
+Stream output to the user as it runs. ConformU can take minutes (especially for cameras and telescopes). Do not interrupt unless the user says so.
+
+If the run errors out before producing a log (e.g. SIGSEGV, missing .NET runtime), surface the error message verbatim and stop — do not proceed to validation.
+
+## Step 4 — Validate results (HARD GATE)
+
+Validation must check **all four** signals. A pass requires all four to be clean. This mirrors `/driver-build` Step 10 and the `/commit` hard-block.
+
+### 4a. JSON report counts (preferred — most reliable)
+
+```bash
+jq -r '{ErrorCount, IssueCount, ConfigurationAlertCount, TimingIssuesCount}' "$TMPDIR/conform.report.json"
+```
+
+**Fail** if `ErrorCount`, `IssueCount`, or `TimingIssuesCount` is non-zero. `ConfigurationAlertCount` is informational — report it but do NOT block on it.
+
+### 4b. Text log — pass message present
+
+```bash
+grep -q "Congratulations, no errors, warnings or issues found" "$TMPDIR/conformu.txt"
+```
+
+**Fail** if absent.
+
+### 4c. Text log — no timing violations
+
+```bash
+grep -nE "OUTSIDE (FAST|STANDARD|EXTENDED) RESPONSE TIME TARGET" "$TMPDIR/conformu.txt"
+grep -n "took longer than its target response time" "$TMPDIR/conformu.txt"
+```
+
+**Fail** if either grep matches.
+
+### 4d. Show a summary table
+
+Regardless of pass/fail, show the user a concise summary:
+
+```
+ConformU 4.3.0 — <vendor> <model> (<type>) over <transport>
+  Errors:           0
+  Issues:           0
+  ConfigAlerts:     0
+  TimingIssues:     0
+  Slowest member:   Name (0.409s, target 0.1s)   ← only if any timing issue
+  Pass message:     Present
+  Verdict:          PASS / FAIL
+```
+
+The slowest-member line is helpful even on a pass — call it out if any member came within 80% of its target (`grep "(FAST)\|(STANDARD)\|(EXTENDED)"` and pick the closest-to-limit row).
+
+## Step 5 — On failure — diagnose and fix the driver
+
+Do NOT save the failing ConformU log to `AlpacaCore/conformu/`. That directory is the source of truth for `SUPPORTED-DRIVERS.md` and must not contain polluted results.
+
+### 5a. Show the failure summary
+
+1. The summary table from Step 4d.
+2. The specific failing operations:
+   - For errors/issues — extract matching lines from `$TMPDIR/conformu.txt`.
+   - For timing — list each `OUTSIDE … RESPONSE TIME TARGET` line with member name, actual time, and target.
+
+### 5b. Pull the AlpacaBridge TRACE log for the test window
+
+The TRACE log captured during Step 3 is the most valuable diagnostic. Retrieve it and slice to the test window (baseline timestamp from Step 2f → now):
+
+```bash
+curl -sS --max-time 10 "http://<host>:<port>/management/v1/logs?ClientID=1&ClientTransactionID=1" \
+  | jq -r '.Value' > "$TMPDIR/ab.log"
+```
+
+If the file is large, also keep a sliced copy for analysis:
+
+```bash
+awk -v start="<run-start-baseline>" '$0 ~ start, /./' "$TMPDIR/ab.log" > "$TMPDIR/ab.window.log"
+```
+
+(If the awk slice is empty because the timestamp format doesn't match line-for-line, fall back to using the full log.)
+
+### 5c. Correlate ConformU failures with AB log entries
+
+For each failing operation in the ConformU log, extract its timestamp (`HH:MM:SS.fff`) and the operation name (`SlewToCoordinates`, `Tracking Write`, `Name`, `PulseGuide East 2s`, etc.). Then:
+
+```bash
+# Find AB log lines within ~2 seconds of the failing operation, mentioning the operation or its underlying driver method
+grep -n "<HH:MM:SS>" "$TMPDIR/ab.window.log" | head -50
+grep -nE "<driver_method_pattern>" "$TMPDIR/ab.window.log" | head -50
+```
+
+For each failing operation, build a short evidence block — quote the matched AB log lines (timestamps, component, message) so the diagnosis is grounded in actual driver behavior, not guesses.
+
+### 5d. Root-cause analysis
+
+Map evidence to a likely root cause. Common patterns (the same list as `/driver-build` Step 10, now informed by the TRACE log):
+
+| Symptom in ConformU | Look for in AB TRACE log | Likely root cause |
+|---------------------|--------------------------|-------------------|
+| Slow `Name` (>0.1s FAST) | First call into SDK takes long; subsequent calls fast | Cold SDK warm-up — call identity once during connect |
+| Slow position read (RA, Dec, Position, Temperature) | Each read triggers a serial/TCP round-trip | Add short TTL cache in the protocol/SDK wrapper |
+| Slow property writes (Tracking Write, Site* Write, GuideRate*) | Long mutex hold spanning network I/O | Release driver mutex around the network call |
+| Slow async initiator (SlewToCoordinatesAsync, PulseGuide) | Initiator blocks on full SDK call | Defer SDK work to a background task |
+| `OUTSIDE EXTENDED` on slew/exposure | Polling loop running too slow or sleeping too long | Tighten poll interval; trust the mount/SDK status register |
+| `InvalidValue` expected but got `DriverException` | Wrong exception type thrown in driver | Use `AlpacaException(AlpacaError::InvalidValue, ...)` |
+| `MethodNotImplemented` expected but got `DriverException` | Capability check missing or wrong code | Return correct `AlpacaError` for unsupported features |
+| State machine mismatch (Slewing, IsPulseGuiding, CameraState) | Flag never set/cleared; race condition | Audit the state transitions and mutex coverage |
+
+For each failing operation, state the diagnosis as: **`<member>` failed with `<symptom>`. AB TRACE shows `<quoted evidence>`. Root cause: `<one-line>`. Fix: `<specific change to specific file>`.**
+
+### 5e. Locate the driver source and propose the fix
+
+```bash
+ls AlpacaCore/src/vendors/<vendor>/
+ls AlpacaCore/include/alpacacore/vendor/<vendor>/
+```
+
+For each diagnosed issue, identify the exact file + function + lines to change, and draft the patch. Show the proposed diff to the user (with surrounding context) and ask for approval before applying.
+
+Honor the project rules from `/driver-build`:
+- Don't touch the Alpaca interface header (`AlpacaCore/include/alpacacore/<device>_driver.h`) unless the spec genuinely demands it.
+- Driver `.cpp` calls the wrapper; the wrapper does protocol/SDK I/O. Don't add raw SDK calls to the driver.
+- SSPL license headers stay intact.
+- Don't add error handling or fallbacks for scenarios that can't happen — fix the actual cause.
+
+### 5f. Apply the fix
+
+After user approval, apply each edit. If multiple files are touched, group them logically. Run the unit tests for the vendor:
+
+```bash
+cd AlpacaCore && cmake --build build --target alpacacore_tests && ./build/tests/alpacacore_tests "[<vendor>]"
+```
+
+If unit tests pass, tell the user:
+
+> "Fix applied to `<files>`. Unit tests pass. To verify against hardware: rebuild AlpacaBridge (`./build_and_run.sh`), wait for the device to reconnect, then re-run `/conformu <vendor> <model>`. The log level is still TRACE — Step 8 will restore it after the next successful run, or run `/conformu` again to keep iterating."
+
+Do NOT rebuild AlpacaBridge from this skill (matches the "assume running" decision in Step 2). Do NOT auto-restart the process. The user owns AB's lifecycle.
+
+### 5g. If diagnosis is unclear
+
+If TRACE evidence is thin or contradictory, do NOT guess a fix. Tell the user honestly:
+
+> "ConformU shows `<failure>` but the AB TRACE log doesn't clearly explain it. I can see `<observations>`. Options: (1) add more logging in `<driver function>` and re-run, (2) reproduce manually with curl against the same endpoint, (3) check existing INDI/INDIGO drivers for how they handle this method. Which would you like?"
+
+Do NOT save the failing ConformU log. Do NOT update SUPPORTED-DRIVERS.md. Stop after the diagnosis is delivered.
+
+## Step 6 — On pass — sanity-check AB logs, then save
+
+### 6a. Scan AB TRACE log for hidden warnings or errors
+
+Even when ConformU passes, the AB log can reveal latent issues — silently swallowed exceptions, retried SDK calls, surprise reconnects. Fetch the log and grep:
+
+```bash
+curl -sS --max-time 10 "http://<host>:<port>/management/v1/logs?ClientID=1&ClientTransactionID=1" \
+  | jq -r '.Value' > "$TMPDIR/ab.log"
+grep -nE "WARN|ERROR|CRITICAL|exception|retry|timeout|reconnect" "$TMPDIR/ab.log" | head -30
+```
+
+If matches appear, show them to the user. A passing ConformU with a stack trace in the AB log is still a yellow flag — ask the user whether to proceed with saving or to investigate first. Default to proceeding only after the user confirms the matches are benign (e.g. expected NotConnected errors during a controlled disconnect test).
+
+### 6b. Save logs
+
+Compute the destination directory:
+
+```
+AlpacaCore/conformu/<Vendor>/<Model>/
+```
+
+- `<Vendor>` uses the canonical case from Step 1.
+- `<Model>` uses the canonical case from Step 1.
+- Some vendors group by SDK family (e.g. `ZWO/ASI/`, `ZWO/EAF/`). Check existing subdirs under the vendor before creating a new top-level model dir; ask the user if a grouping subdir applies.
+
+Filenames:
+- Single transport: `Linux-arm64.txt` + `Linux-arm64.report.json`
+- Multiple transports: `Linux-arm64-<transport>.txt` + `Linux-arm64-<transport>.report.json` (lowercase: `usb`, `wifi`, `serial`, `tcp`)
+
+Always save BOTH the text log and the JSON report (the JSON preserves the timing data even after a fresh ConformU release changes the text format).
+
+```bash
+mkdir -p "AlpacaCore/conformu/<Vendor>/<Model>"
+cp "$TMPDIR/conformu.txt"          "AlpacaCore/conformu/<Vendor>/<Model>/Linux-arm64[-<transport>].txt"
+cp "$TMPDIR/conform.report.json"   "AlpacaCore/conformu/<Vendor>/<Model>/Linux-arm64[-<transport>].report.json"
+```
+
+If a file with the same name already exists, show the user the diff in counts (old vs new) and ask whether to overwrite. Overwriting a passing result with another passing result is usually fine (e.g. re-validating against a newer ConformU); overwriting a passing result for a different transport is a mistake.
+
+## Step 7 — Update SUPPORTED-DRIVERS.md
+
+Read `SUPPORTED-DRIVERS.md` and locate the section for this device type (`## Camera Drivers`, `## Telescope Drivers`, etc.).
+
+### 7a. Table row
+
+Find the vendor's `### <Vendor>` subsection in that device-type section. If absent, create a new vendor subsection following the existing format:
+
+```
+### <Vendor>
+
+| Model Series | Connection | Linux<br>(arm64) | Status |
+|--------------|------------|------------------|--------|
+| <Model> | <Transport> | ✓ | [ConformU Validation](AlpacaCore/conformu/<Vendor>/<Model>/) |
+```
+
+URL-encode spaces in the path link as `%20` (e.g. `Player%20One`, `Ceres%20462M`).
+
+If a row for this exact model already exists:
+- If it was previously `pending arm64 re-validation` or had no ✓, update the row to add the ✓ and the link.
+- If it already had ✓ and a link, no change needed (the log file was just refreshed).
+- If the connection cell needs to gain a second transport (e.g. `USB` → `USB, Wi-Fi`), update it.
+
+### 7b. Driver Notes
+
+After the table, find the `### <Vendor> Driver Notes` (or `### <Vendor> <DeviceType> Driver Notes`) section. If absent, add one in the existing format:
+
+```
+### <Vendor> <DeviceType> Driver Notes
+
+- **SDK**: <SDK name + version> (or **Protocol**: <spec version> for non-SDK devices)
+- **Connection**: <Transport> (<details, e.g. baud rate, default IP>)
+- **Tested model**: <Model> on Linux arm64
+- **ConformU**: <version> — 0 errors, 0 issues, 0 timing issues
+```
+
+If the notes already exist, append a new tested-model line or update the existing one — do not duplicate. Ask the user for SDK/protocol version details if you don't already have them from the session.
+
+### 7c. Updated date
+
+Update the `## Updated YYYY-MM-DD` line near the top of the file to today's date.
+
+### 7d. Confirm before writing
+
+Show the user the exact diff that will be applied (added row, added Driver Notes lines, updated date) and confirm before saving.
+
+## Step 8 — Restore the original AB log level (MANDATORY — every exit path)
+
+Whether the run passed, failed, or was aborted mid-flow, restore the log level captured in Step 2d. The persisted setting would otherwise leave AB at TRACE indefinitely, bloating disk and slowing all subsequent operations.
+
+```bash
+curl -sS --max-time 5 -X PUT "http://<host>:<port>/management/v1/loglevel" \
+  -H "Content-Type: application/json" \
+  -d "{\"Level\":\"<original-level>\",\"ClientID\":1,\"ClientTransactionID\":1}"
+```
+
+If AB is unreachable at this point (crashed during the test), tell the user explicitly:
+
+> "Could not restore AB log level — AlpacaBridge is not reachable. When you restart AB, run: `curl -X PUT http://<host>:<port>/management/v1/loglevel -H 'Content-Type: application/json' -d '{\"Level\":\"<original-level>\"}'`"
+
+This restore step runs at the end of every Step 5 failure path AND at the end of every Step 6/7 success path. Do not skip it.
+
+## Step 9 — Hand off to /commit (pass path only)
+
+After files are saved and `SUPPORTED-DRIVERS.md` is updated, tell the user:
+
+> "ConformU validated — 0 errors, 0 issues, 0 timing issues. Saved to `AlpacaCore/conformu/<Vendor>/<Model>/`. SUPPORTED-DRIVERS.md updated. AB log level restored to `<original-level>`. Run `/commit` to stage and commit these changes — the hard-block in `/commit` Step 3 will re-verify the report counts as a final safety net before the commit lands."
+
+Do NOT run `git add` or `git commit` from this skill. Leave staging and commit message authoring to `/commit`, which has the proper component grouping, CHANGELOG handling, and the redundant ConformU validation gate.
+
+## Workflow notes
+
+- This skill assumes Linux arm64 only. AlpacaBridge does not support amd64; do not save reports under any other platform name.
+- If the run is interrupted (Ctrl-C, network drop, AlpacaBridge crash), discard the partial logs in `$TMPDIR` and start over after fixing the cause.
+- Never edit a saved ConformU log by hand to "fix" timing or counts — that is the worst possible thing to do to the validation record. If a log is wrong, delete it and re-run.

--- a/.claude/commands/driver-build.md
+++ b/.claude/commands/driver-build.md
@@ -527,10 +527,36 @@ arm64 is not just Raspberry Pi — the project supports a growing range of arm64
 
 1. Build AlpacaBridge with the new driver enabled.
 2. Start AlpacaBridge with the new driver configured and connected to real hardware.
-3. Run ConformU against the device. Target: **0 errors, 0 issues**.
-4. Save the ConformU results log to `AlpacaCore/conformu/<vendor>/<model>/Linux-arm64.txt`.
+3. Run ConformU against the device. Target: **0 errors, 0 issues, 0 timing issues**.
+4. **Verify the Timing Summary** at the end of the ConformU log — this is a separate pass criterion from the main "no errors, warnings or issues found" message. A clean run MUST satisfy all of:
+   - No `OUTSIDE FAST RESPONSE TIME TARGET` lines
+   - No `OUTSIDE STANDARD RESPONSE TIME TARGET` lines
+   - No `OUTSIDE EXTENDED RESPONSE TIME TARGET` lines
+   - No trailing `N member(s) took longer than its target response time.` summary line
+   - If a JSON report (`conform.report.txt`) is produced, `"TimingIssuesCount": 0`
+
+   Per-spec response time targets (reported in the Timing Summary header):
+   - **FAST** — 0.1 seconds (configuration and state reporting members, e.g. `Name`, `Connected`, `CanXxx`, position reads)
+   - **STANDARD** — 1.0 second (property writes and asynchronous initiators, e.g. `Tracking Write`, `SlewToCoordinatesAsync`)
+   - **EXTENDED** — 600.0 seconds (synchronous methods, `ImageArray`, `ImageArrayVariant`)
+
+   Quick check after a run:
+   ```bash
+   grep -E "OUTSIDE (FAST|STANDARD|EXTENDED) RESPONSE TIME TARGET|took longer than its target response time" <conformu.log>
+   grep '"TimingIssuesCount"' <conform.report.txt>   # if JSON report is produced
+   ```
+   Both must return either nothing or `"TimingIssuesCount": 0`.
+
+   If any member exceeds its target, treat it as a failure. Common root causes (see "Common ConformU failure patterns" below for the full list):
+   - Slow SDK control writes — defer to start of operation or cache
+   - Network I/O while holding the driver mutex — release before I/O, re-acquire after
+   - Repeated round-trips for cached values (RA/Dec, capabilities) — add a short TTL cache
+   - First-call SDK warm-up on `Name`/identity reads — warm up at connect
+
+5. Save the ConformU results to `AlpacaCore/conformu/<vendor>/<model>/Linux-arm64.txt`.
    - If the device supports multiple connection types, save separate results: `Linux-arm64-usb.txt`, `Linux-arm64-wifi.txt`.
-5. If ConformU reveals failures, fix them and re-run until clean.
+   - If ConformU also produced a JSON report, save it alongside the text log (e.g. `Linux-arm64.report.json`) so the timing data is preserved.
+6. If ConformU reveals failures (errors, issues, OR timing issues), fix them and re-run until clean.
 
 ### After validation — update SUPPORTED-DRIVERS.md (MANDATORY)
 

--- a/.claude/commands/submit-pr.md
+++ b/.claude/commands/submit-pr.md
@@ -35,6 +35,35 @@ git log @{u}..HEAD --oneline 2>/dev/null || echo "NO_UPSTREAM"
 
 - If there are unpushed commits or no upstream tracking branch, note this — the branch will need to be pushed in Step 4.
 
+### ConformU report validation (HARD BLOCK)
+
+If this branch adds or modifies any ConformU files under `AlpacaCore/conformu/**`, every report must pass before the PR can be submitted. Merging a failing report misleads downstream consumers of `SUPPORTED-DRIVERS.md` into thinking a driver is validated on arm64.
+
+Find the reports on this branch:
+
+```bash
+git diff --name-only main..HEAD | grep -E '^AlpacaCore/conformu/.*\.(json|txt)$'
+```
+
+If the list is empty, skip the rest of this subsection.
+
+For each file in the list:
+
+- **JSON reports** (`*.json`) — **fail** if any of `ErrorCount`, `IssueCount`, `TimingIssuesCount` is non-zero:
+  ```bash
+  jq -r '{ErrorCount, IssueCount, TimingIssuesCount}' <file>
+  ```
+- **Text logs** (`*.txt`) — **fail** if any of these are true:
+  - `grep -E "OUTSIDE (FAST|STANDARD|EXTENDED) RESPONSE TIME TARGET" <file>` matches
+  - `grep "took longer than its target response time" <file>` matches
+  - The file does NOT contain `Congratulations, no errors, warnings or issues found`
+
+If any file fails, **STOP**. Do NOT push. Do NOT open the PR. Tell the user exactly which file and which counts/lines failed:
+
+> "ConformU report `<file>` shows Errors=N, Issues=N, TimingIssues=N (or matching grep lines). The driver is not validated. Fix the driver, re-run ConformU until clean, replace the report on this branch, and try again. PR is blocked until every ConformU report on this branch passes. See `/driver-build` Step 10 for the full pass criteria."
+
+Do NOT offer to open the PR "anyway", as a draft, or with a TODO. This block exists because a green-looking PR with a failing ConformU report is the worst-case outcome — it gets merged and misadvertises the driver as validated.
+
 ## Step 2 — Detect repository setup
 
 Determine whether the user is a direct contributor or working from a fork:
@@ -80,7 +109,7 @@ Read the full diff and all commit messages. Understand:
 Review the branch contents and warn the user about anything that's missing:
 
 - [ ] **Unit tests**: Does the branch include Catch2 tests? (required for all driver code)
-- [ ] **ConformU results**: If this is a driver PR, is an arm64 ConformU report included?
+- [ ] **ConformU results**: If this is a driver PR, is an arm64 ConformU report included AND clean (verified in Step 1 — errors=0, issues=0, timing issues=0)?
 - [ ] **CHANGELOG.md**: Is there an entry under `## [x.x.x] - UNRELEASED`?
 - [ ] **SUPPORTED-DRIVERS.md**: If this adds or validates a driver, is the table updated?
 - [ ] **AGENTS.md**: Were lessons learned captured?


### PR DESCRIPTION
## Summary
- Adds a new `/conformu` skill that drives a ConformU conformance run end-to-end (TRACE-level AB logs, ConformU execution, hard pass/fail gating, log slicing + root-cause diagnosis on failure, results saved under `AlpacaCore/conformu/<Vendor>/<Model>/`, `SUPPORTED-DRIVERS.md` updated).
- Hardens the `commit` and `submit-pr` skills to refuse to commit or open a PR when any ConformU report on the branch has non-zero `ErrorCount`, `IssueCount`, or `TimingIssuesCount`, or matches "OUTSIDE … RESPONSE TIME TARGET" in the text log.
- Updates `driver-build` Step 10 to explicitly require Timing Summary verification (no per-target outside-target lines, no "took longer than its target response time" summary, `TimingIssuesCount=0` in JSON), and to save the ConformU JSON alongside the text log so the timing data survives.

## Changes
- **`/conformu` skill** (`.claude/commands/conformu.md`, new, 398 lines): full workflow including log-level save/restore on every exit path, AB log fetch via `/management/v1/logs`, test-window slicing, symptom→cause mapping table, and approval-gated driver edits.
- **`/commit` skill** (`.claude/commands/commit.md`): new Step 3 HARD BLOCK that re-runs the same ConformU report check; later steps renumbered.
- **`/submit-pr` skill** (`.claude/commands/submit-pr.md`): new HARD BLOCK in Step 1 mirroring the commit guard, plus checklist updates.
- **`/driver-build` skill** (`.claude/commands/driver-build.md`): Step 10 now spells out the Timing Summary criteria and requires saving the JSON report next to the text log.

## Test plan
- [ ] Future driver work invokes `/conformu`; verify the skill completes, saves the report, and updates `SUPPORTED-DRIVERS.md`
- [ ] Drop a failing ConformU report on a feature branch and confirm both `/commit` and `/submit-pr` refuse to proceed
- [ ] Verify the JSON report is saved alongside the text log after a clean run

## Rationale
A green-looking PR with a failing ConformU report is the worst-case outcome — it gets merged and misadvertises the driver as validated. Defense in depth across `commit` and `submit-pr` makes that miss harder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development workflow documentation to include enhanced validation checks for quality assurance processes.

**Note:** This release contains only internal documentation updates with no user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-astro/AlpacaBridge/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->