### PR TITLE
Add GPIO transport to /conformu skill input/output schema

### DIFF
--- a/.claude/commands/conformu.md
+++ b/.claude/commands/conformu.md
@@ -30,7 +30,7 @@ Ask the following **one at a time**, waiting for each answer before moving on. I
 
 3. **ASCOM device type** — Camera, CoverCalibrator, Dome, FilterWheel, Focuser, ObservingConditions, Rotator, SafetyMonitor, Switch, Telescope. Needed to build the Alpaca URI path segment (`camera`, `telescope`, etc. — lowercase).
 
-4. **Connection transport** — USB, Wi-Fi, Serial, or TCP. Used as the filename suffix and as the connection cell in `SUPPORTED-DRIVERS.md`. The on-disk suffix is lowercase (`usb`, `wifi`, `serial`, `tcp`). The table cell uses display form (`USB`, `Wi-Fi`, `Serial`, `TCP`).
+4. **Connection transport** — USB, Wi-Fi, Serial, TCP, or GPIO. Used as the filename suffix and as the connection cell in `SUPPORTED-DRIVERS.md`. The on-disk suffix is lowercase (`usb`, `wifi`, `serial`, `tcp`, `gpio`). The table cell uses display form (`USB`, `Wi-Fi`, `Serial`, `TCP`, `Local GPIO (libgpiod v2)`). Use `GPIO` for devices that AlpacaBridge controls via on-board Linux GPIO lines on the host SBC (e.g. ZWO ASIair Pro 12V power switch on a Raspberry Pi 4).
    - If the device only supports one transport, omit the suffix — file is `Linux-arm64.txt`.
    - If the device supports multiple and this run only tests one, use the suffix — file is `Linux-arm64-<transport>.txt`. Existing reports already exist for the same device — those other transports stay untouched.
 
@@ -309,7 +309,7 @@ AlpacaCore/conformu/<Vendor>/<Model>/
 
 Filenames:
 - Single transport: `Linux-arm64.txt` + `Linux-arm64.report.json`
-- Multiple transports: `Linux-arm64-<transport>.txt` + `Linux-arm64-<transport>.report.json` (lowercase: `usb`, `wifi`, `serial`, `tcp`)
+- Multiple transports: `Linux-arm64-<transport>.txt` + `Linux-arm64-<transport>.report.json` (lowercase: `usb`, `wifi`, `serial`, `tcp`, `gpio`)
 
 Always save BOTH the text log and the JSON report (the JSON preserves the timing data even after a fresh ConformU release changes the text format).
 


### PR DESCRIPTION
## Summary
- Adds \`GPIO\` to the \`/conformu\` skill's transport menu (Step 1.4) and to the filename suffix list (Step 6b), so the ZWO ASIair Pro Switch — the first AlpacaBridge driver that talks to hardware via host-SBC Linux GPIO instead of USB/Wi-Fi/Serial/TCP — can be validated and saved without ad-hoc workarounds.
- Trivial two-line change to \`.claude/commands/conformu.md\`. No code, no behavior outside the skill, no other vendors affected.

## Changes
- **Step 1.4 (transport input)**: menu now \`USB, Wi-Fi, Serial, TCP, or GPIO\`. Lowercase suffix list gains \`gpio\`. Display form for the SUPPORTED-DRIVERS.md table cell is \`Local GPIO (libgpiod v2)\`. Adds one sentence calling out the use case (Pi-4-based ASIair Pro 12V power switch).
- **Step 6b filename schema**: lowercase suffix list gains \`gpio\` so multi-transport devices that add a libgpiod path later get \`Linux-arm64-gpio.txt\` / \`.report.json\` consistently.

## Test plan
- [x] Skill file syntactically valid (markdown, no broken anchors).
- [ ] Re-run \`/conformu\` against the ZWO ASIair Pro Switch — the prompt should now accept GPIO without warning, and save logs to \`AlpacaCore/conformu/ZWO/ASIair Pro/Linux-arm64.txt\` (single transport, no suffix) per the existing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)