### PR TITLE
Update copyright headers to 2025-2026 year range

### DIFF
--- a/AlpacaCore/.cursor/rules/driver_test.mdc
+++ b/AlpacaCore/.cursor/rules/driver_test.mdc
@@ -150,7 +150,7 @@ TEST_CASE("ZWO Camera - Connection States", "[zwo][camera]") {
 
 ```cpp
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/.cursor/rules/rules.mdc
+++ b/AlpacaCore/.cursor/rules/rules.mdc
@@ -55,7 +55,7 @@ All source files must contain:
 
 ```cpp
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/alpaca_defs.h
+++ b/AlpacaCore/include/alpacacore/alpaca_defs.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/alpaca_errors.h
+++ b/AlpacaCore/include/alpacacore/alpaca_errors.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/alpaca_json.h
+++ b/AlpacaCore/include/alpacacore/alpaca_json.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/alpacadriver.h
+++ b/AlpacaCore/include/alpacacore/alpacadriver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/camera_driver.h
+++ b/AlpacaCore/include/alpacacore/camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/covercalibrator_driver.h
+++ b/AlpacaCore/include/alpacacore/covercalibrator_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/device_capabilities.h
+++ b/AlpacaCore/include/alpacacore/device_capabilities.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/device_registry.h
+++ b/AlpacaCore/include/alpacacore/device_registry.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/dome_driver.h
+++ b/AlpacaCore/include/alpacacore/dome_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/filterwheel_driver.h
+++ b/AlpacaCore/include/alpacacore/filterwheel_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/focuser_driver.h
+++ b/AlpacaCore/include/alpacacore/focuser_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/managementdriver.h
+++ b/AlpacaCore/include/alpacacore/managementdriver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/observingconditions_driver.h
+++ b/AlpacaCore/include/alpacacore/observingconditions_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/rotator_driver.h
+++ b/AlpacaCore/include/alpacacore/rotator_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/safetymonitor_driver.h
+++ b/AlpacaCore/include/alpacacore/safetymonitor_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/shutter_driver.h
+++ b/AlpacaCore/include/alpacacore/shutter_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/switch_driver.h
+++ b/AlpacaCore/include/alpacacore/switch_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/util/error_handling.h
+++ b/AlpacaCore/include/alpacacore/util/error_handling.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/util/logging.h
+++ b/AlpacaCore/include/alpacacore/util/logging.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/util/threading.h
+++ b/AlpacaCore/include/alpacacore/util/threading.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/util/units.h
+++ b/AlpacaCore/include/alpacacore/util/units.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/bisque/bisque_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/bisque/bisque_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/bisque/bisque_telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/bisque/bisque_telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/celestron/celestron_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/celestron/celestron_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/celestron/celestron_telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/celestron/celestron_telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/gemini/gemini_focuser_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/gemini/gemini_focuser_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/gemini/gemini_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/gemini/gemini_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/ioptron/ioptron_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/ioptron/ioptron_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/ioptron/ioptron_telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/ioptron/ioptron_telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/playerone/playerone_camera_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/playerone/playerone_camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/playerone/playerone_sdk_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/playerone/playerone_sdk_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/qhy/qhy_camera_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/qhy/qhy_camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/qhy/qhy_sdk_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/qhy/qhy_sdk_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/svbony/svbony_camera_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/svbony/svbony_camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/svbony/svbony_sdk_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/svbony/svbony_sdk_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/synscan/synscan_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/synscan/synscan_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/synscan/synscan_telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/synscan/synscan_telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/touptek/touptek_camera_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/touptek/touptek_camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/touptek/touptek_focuser_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/touptek/touptek_focuser_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/touptek/touptek_sdk_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/touptek/touptek_sdk_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/weewx/weewx_observingconditions_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/weewx/weewx_observingconditions_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_plus_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_plus_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_plus_switch_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_plus_switch_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_switch_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_asiair_switch_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_caa_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_caa_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_camera_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_camera_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_eaf_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_eaf_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_efw_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_efw_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_filterwheel_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_filterwheel_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_focuser_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_focuser_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_mount_protocol_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_mount_protocol_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_rotator_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_rotator_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_sdk_wrapper.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_sdk_wrapper.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_switch_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_switch_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/include/alpacacore/vendor/zwo/zwo_telescope_driver.h
+++ b/AlpacaCore/include/alpacacore/vendor/zwo/zwo_telescope_driver.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/alpaca_defs.cpp
+++ b/AlpacaCore/src/core/alpaca_defs.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/alpaca_errors.cpp
+++ b/AlpacaCore/src/core/alpaca_errors.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/alpaca_json.cpp
+++ b/AlpacaCore/src/core/alpaca_json.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/alpacadriver.cpp
+++ b/AlpacaCore/src/core/alpacadriver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/device_capabilities.cpp
+++ b/AlpacaCore/src/core/device_capabilities.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/managementdriver.cpp
+++ b/AlpacaCore/src/core/managementdriver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/util/error_handling.cpp
+++ b/AlpacaCore/src/core/util/error_handling.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/util/logging.cpp
+++ b/AlpacaCore/src/core/util/logging.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/util/threading.cpp
+++ b/AlpacaCore/src/core/util/threading.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/core/util/units.cpp
+++ b/AlpacaCore/src/core/util/units.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/camera_driver.cpp
+++ b/AlpacaCore/src/drivers/camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/covercalibrator_driver.cpp
+++ b/AlpacaCore/src/drivers/covercalibrator_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/dome_driver.cpp
+++ b/AlpacaCore/src/drivers/dome_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/filterwheel_driver.cpp
+++ b/AlpacaCore/src/drivers/filterwheel_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/focuser_driver.cpp
+++ b/AlpacaCore/src/drivers/focuser_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/observingconditions_driver.cpp
+++ b/AlpacaCore/src/drivers/observingconditions_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/rotator_driver.cpp
+++ b/AlpacaCore/src/drivers/rotator_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/safetymonitor_driver.cpp
+++ b/AlpacaCore/src/drivers/safetymonitor_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/shutter_driver.cpp
+++ b/AlpacaCore/src/drivers/shutter_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/switch_driver.cpp
+++ b/AlpacaCore/src/drivers/switch_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/drivers/telescope_driver.cpp
+++ b/AlpacaCore/src/drivers/telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/management/device_registry.cpp
+++ b/AlpacaCore/src/management/device_registry.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/management/discovery_service.cpp
+++ b/AlpacaCore/src/management/discovery_service.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/bisque/bisque_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/bisque/bisque_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/bisque/bisque_telescope_driver.cpp
+++ b/AlpacaCore/src/vendors/bisque/bisque_telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/celestron/celestron_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/celestron/celestron_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/celestron/celestron_telescope_driver.cpp
+++ b/AlpacaCore/src/vendors/celestron/celestron_telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/gemini/gemini_focuser_driver.cpp
+++ b/AlpacaCore/src/vendors/gemini/gemini_focuser_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/gemini/gemini_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/gemini/gemini_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/ioptron/ioptron_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/ioptron/ioptron_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/ioptron/ioptron_telescope_driver.cpp
+++ b/AlpacaCore/src/vendors/ioptron/ioptron_telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/playerone/playerone_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/playerone/playerone_camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/playerone/playerone_sdk_wrapper.cpp
+++ b/AlpacaCore/src/vendors/playerone/playerone_sdk_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/qhy/qhy_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/qhy/qhy_camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/qhy/qhy_sdk_wrapper.cpp
+++ b/AlpacaCore/src/vendors/qhy/qhy_sdk_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/svbony/svbony_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/svbony/svbony_camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/svbony/svbony_sdk_wrapper.cpp
+++ b/AlpacaCore/src/vendors/svbony/svbony_sdk_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/synscan/synscan_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/synscan/synscan_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/synscan/synscan_telescope_driver.cpp
+++ b/AlpacaCore/src/vendors/synscan/synscan_telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/touptek/touptek_focuser_driver.cpp
+++ b/AlpacaCore/src/vendors/touptek/touptek_focuser_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/touptek/touptek_sdk_wrapper.cpp
+++ b/AlpacaCore/src/vendors/touptek/touptek_sdk_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/weewx/weewx_observingconditions_driver.cpp
+++ b/AlpacaCore/src/vendors/weewx/weewx_observingconditions_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_asiair_plus_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_asiair_plus_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_asiair_plus_switch_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_asiair_plus_switch_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_asiair_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_asiair_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_asiair_switch_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_asiair_switch_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_caa_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_caa_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_camera_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_eaf_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_eaf_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_efw_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_efw_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_filterwheel_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_filterwheel_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_focuser_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_focuser_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_mount_protocol_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_mount_protocol_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_rotator_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_rotator_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_sdk_wrapper.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_sdk_wrapper.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_switch_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_switch_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/src/vendors/zwo/zwo_telescope_driver.cpp
+++ b/AlpacaCore/src/vendors/zwo/zwo_telescope_driver.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/catch2_compat.h
+++ b/AlpacaCore/tests/catch2_compat.h
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_alpaca_defs.cpp
+++ b/AlpacaCore/tests/test_alpaca_defs.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_bisque_telescope.cpp
+++ b/AlpacaCore/tests/test_bisque_telescope.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_celestron_telescope.cpp
+++ b/AlpacaCore/tests/test_celestron_telescope.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_device_registry.cpp
+++ b/AlpacaCore/tests/test_device_registry.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_error_handling.cpp
+++ b/AlpacaCore/tests/test_error_handling.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_gemini_focuser.cpp
+++ b/AlpacaCore/tests/test_gemini_focuser.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_ioptron_telescope.cpp
+++ b/AlpacaCore/tests/test_ioptron_telescope.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_playerone_camera.cpp
+++ b/AlpacaCore/tests/test_playerone_camera.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_qhy_camera.cpp
+++ b/AlpacaCore/tests/test_qhy_camera.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_svbony_camera.cpp
+++ b/AlpacaCore/tests/test_svbony_camera.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_synscan_telescope.cpp
+++ b/AlpacaCore/tests/test_synscan_telescope.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_touptek_camera.cpp
+++ b/AlpacaCore/tests/test_touptek_camera.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_touptek_focuser.cpp
+++ b/AlpacaCore/tests/test_touptek_focuser.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_units.cpp
+++ b/AlpacaCore/tests/test_units.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_weewx_observingconditions.cpp
+++ b/AlpacaCore/tests/test_weewx_observingconditions.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_asiair_plus_switch.cpp
+++ b/AlpacaCore/tests/test_zwo_asiair_plus_switch.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_asiair_switch.cpp
+++ b/AlpacaCore/tests/test_zwo_asiair_switch.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_camera.cpp
+++ b/AlpacaCore/tests/test_zwo_camera.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_filterwheel.cpp
+++ b/AlpacaCore/tests/test_zwo_filterwheel.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_focuser.cpp
+++ b/AlpacaCore/tests/test_zwo_focuser.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_rotator.cpp
+++ b/AlpacaCore/tests/test_zwo_rotator.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_switch.cpp
+++ b/AlpacaCore/tests/test_zwo_switch.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaCore/tests/test_zwo_telescope.cpp
+++ b/AlpacaCore/tests/test_zwo_telescope.cpp
@@ -1,5 +1,5 @@
 // AlpacaCore
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaCore.
 //

--- a/AlpacaHTTP/.cursor/rules/rules.mdc
+++ b/AlpacaHTTP/.cursor/rules/rules.mdc
@@ -50,7 +50,7 @@ Include this header at the top of all new `.h` and `.cpp` files:
 
 ```cpp
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/examples/simple_server/main.cpp
+++ b/AlpacaHTTP/examples/simple_server/main.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/config.h
+++ b/AlpacaHTTP/include/alpacahttp/config.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/discovery.h
+++ b/AlpacaHTTP/include/alpacahttp/discovery.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/json_utils.h
+++ b/AlpacaHTTP/include/alpacahttp/json_utils.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/request.h
+++ b/AlpacaHTTP/include/alpacahttp/request.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/response.h
+++ b/AlpacaHTTP/include/alpacahttp/response.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/router.h
+++ b/AlpacaHTTP/include/alpacahttp/router.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/server.h
+++ b/AlpacaHTTP/include/alpacahttp/server.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/util/error_mapping.h
+++ b/AlpacaHTTP/include/alpacahttp/util/error_mapping.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/util/logging_adapter.h
+++ b/AlpacaHTTP/include/alpacahttp/util/logging_adapter.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/util/socket_utils.h
+++ b/AlpacaHTTP/include/alpacahttp/util/socket_utils.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/util/threading.h
+++ b/AlpacaHTTP/include/alpacahttp/util/threading.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/include/alpacahttp/version.h
+++ b/AlpacaHTTP/include/alpacahttp/version.h
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/core/config.cpp
+++ b/AlpacaHTTP/src/core/config.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/core/json_utils.cpp
+++ b/AlpacaHTTP/src/core/json_utils.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/core/request.cpp
+++ b/AlpacaHTTP/src/core/request.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/core/response.cpp
+++ b/AlpacaHTTP/src/core/response.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/discovery/discovery.cpp
+++ b/AlpacaHTTP/src/discovery/discovery.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/http/router.cpp
+++ b/AlpacaHTTP/src/http/router.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/http/server.cpp
+++ b/AlpacaHTTP/src/http/server.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/util/error_mapping.cpp
+++ b/AlpacaHTTP/src/util/error_mapping.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/util/logging_adapter.cpp
+++ b/AlpacaHTTP/src/util/logging_adapter.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/src/util/threading.cpp
+++ b/AlpacaHTTP/src/util/threading.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/tests/test_config.cpp
+++ b/AlpacaHTTP/tests/test_config.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/tests/test_discovery.cpp
+++ b/AlpacaHTTP/tests/test_discovery.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/tests/test_json.cpp
+++ b/AlpacaHTTP/tests/test_json.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //

--- a/AlpacaHTTP/tests/test_routing.cpp
+++ b/AlpacaHTTP/tests/test_routing.cpp
@@ -1,5 +1,5 @@
 // AlpacaHTTP
-// Copyright (c) 2025 Joey Troy and contributors
+// Copyright (c) 2025-2026 Joey Troy and contributors
 //
 // This file is part of AlpacaHTTP.
 //


### PR DESCRIPTION
## Summary
- Extends the per-file copyright notice from "2025" to the range "2025-2026" across all 169 first-party files.
- Keeps 2025 as the first-publication year and advances only the end year, per standard practice.
- Updates the `.cursor/rules` header templates so newly generated files inherit the new format.

## Changes
- **Source/Headers/Tests/Examples** (AlpacaCore + AlpacaHTTP): copyright line updated in all 169 first-party files.
- **Header templates**: `AlpacaCore/.cursor/rules/rules.mdc`, `AlpacaCore/.cursor/rules/driver_test.mdc`, `AlpacaHTTP/.cursor/rules/rules.mdc`.
- **No third-party changes**: MongoDB SSPL, ZWO, PlayerOne, and QHY SDK licenses left untouched.

## Test plan
- [x] Diff is copyright-line-only (169 insertions, 169 deletions, no other content changed)
- [x] AlpacaCore builds; test suite passes (435 assertions in 60 test cases)
- [x] AlpacaHTTP builds; ctest passes (4/4)

This is a comment-only change with no functional impact.