### PR TITLE
ci: harden CI (format set -e, zizmor checksum, unicode scanner)

### DIFF
--- a/.github/scripts/check-unicode.py
+++ b/.github/scripts/check-unicode.py
@@ -3,23 +3,42 @@
 
 Guards against "Trojan Source" attacks (CVE-2021-42574), where bidirectional
 control characters or invisible code points make source render differently from
-how the compiler reads it. The vendored SDK trees under AlpacaCore/external/ are
-imported upstream artifacts we don't author, so they're excluded (same policy as
-clang-format / clang-tidy).
+how the compiler reads it.
 
 Run from the repo root:  python3 .github/scripts/check-unicode.py
 Exits non-zero (and prints file:line:col U+XXXX) if any forbidden code point is
-found.
+found. Intentional control characters in tests should be written as escapes
+(e.g. "\\u200E") rather than literal characters so the source stays clean.
+
+Detection does NOT depend on a file decoding cleanly as UTF-8, and it does not
+silently pass anything it fails to inspect -- both are bypasses a security
+control must not have:
+
+  * Genuine binaries are skipped (a NUL byte, and no UTF-16/UTF-32 BOM).
+  * UTF-8 and BOM-declared UTF-16 / UTF-32 text are decoded and scanned for
+    precise file:line:col reporting.
+  * Any remaining undecodable *text* file is flagged (a non-UTF-8 text file is
+    anomalous in a UTF-8 tree) and byte-scanned for the forbidden code points
+    in every encoding that can carry them.
+  * A tracked file that cannot be read at all (broken symlink, bad perms) is a
+    hard finding -- never skipped silently. Directory targets of tracked
+    symlinks (e.g. macOS .framework internals) are not files and are skipped.
+
+Known accepted limitation: a UTF-16/UTF-32 text file with NO byte-order mark is
+indistinguishable from binary by the NUL heuristic and is skipped. Such a file
+is not valid source for this tree's toolchains (which read UTF-8), so it is not
+a realistic vector here.
 """
 
 import subprocess
 import sys
 
+
 # Forbidden code points keyed by integer value, so this scanner is itself pure
 # ASCII and never trips over its own table. Limited to characters that are
-# unambiguously suspect in an English-language codebase: bidi controls plus
-# zero-width / invisible spaces. ZWJ/ZWNJ (U+200C/U+200D) are intentionally
-# omitted because they appear in legitimate emoji sequences in Markdown.
+# unambiguously suspect in a source tree: bidi controls plus zero-width /
+# invisible spaces. ZWJ/ZWNJ (U+200C/U+200D) are intentionally omitted because
+# they appear in legitimate emoji sequences in Markdown.
 FORBIDDEN = {
     # Bidirectional formatting controls (the core Trojan Source vector)
     0x202A: "LEFT-TO-RIGHT EMBEDDING",
@@ -40,7 +59,48 @@ FORBIDDEN = {
     0xFEFF: "ZERO WIDTH NO-BREAK SPACE (BOM)",
 }
 
-EXCLUDE_PREFIXES = ("AlpacaCore/external/",)
+# Encodings a hidden character could realistically reach a toolchain through.
+# Every forbidden code point is > U+00FF, so single-byte legacy encodings
+# (Latin-1, Windows-1252, ...) physically cannot represent them -- the Unicode
+# transformation formats are the only byte-level vectors. Both endiannesses of
+# UTF-16/UTF-32 are covered.
+BYTE_ENCODINGS = ("utf-8", "utf-16-le", "utf-16-be", "utf-32-le", "utf-32-be")
+
+
+def _build_forbidden_bytes():
+    """{byte sequence: [(codepoint, encoding), ...]} for the raw-byte backstop.
+
+    A list of hits per sequence (not a single value) so that if two code points
+    ever encode to identical bytes the table stays correct instead of silently
+    dropping one. No collision exists today; this keeps it safe as FORBIDDEN
+    grows. Wrapped in a function so the loop variables don't leak to module
+    scope.
+    """
+    table = {}
+    for cp in FORBIDDEN:
+        for enc in BYTE_ENCODINGS:
+            table.setdefault(chr(cp).encode(enc), []).append((cp, enc))
+    return table
+
+
+FORBIDDEN_BYTES = _build_forbidden_bytes()
+
+# Paths under these prefixes are skipped.
+#
+# The vendored SDK trees under AlpacaCore/external/ are third-party camera
+# vendor drops we don't author and can't clean up; some ship BOMs and non-UTF-8
+# demo sources. They're excluded so the scan covers only code we own. Authored
+# source (AlpacaCore/, AlpacaHTTP/, scripts, docs) is always scanned. Add a
+# prefix here only if an upstream import legitimately needs an exception.
+EXCLUDE_PREFIXES = (
+    "AlpacaCore/external/",
+)
+
+# Byte-order marks. UTF-32 must be tested before UTF-16: the UTF-32-LE BOM
+# (FF FE 00 00) starts with the UTF-16-LE BOM (FF FE), so a naive UTF-16 check
+# would misdecode UTF-32-LE as UTF-16 garbage.
+_UTF32_BOMS = (b"\xff\xfe\x00\x00", b"\x00\x00\xfe\xff")
+_UTF16_BOMS = (b"\xff\xfe", b"\xfe\xff")
 
 
 def tracked_files():
@@ -49,32 +109,103 @@ def tracked_files():
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",  # decode paths as UTF-8 regardless of runner locale
     ).stdout
     for path in out.split("\0"):
         if path and not path.startswith(EXCLUDE_PREFIXES):
             yield path
 
 
+def looks_binary(data):
+    """A NUL byte means binary -- unless a UTF-16/UTF-32 BOM marks it as text."""
+    if not data:
+        return False
+    if data.startswith(_UTF32_BOMS) or data.startswith(_UTF16_BOMS):
+        return False
+    return b"\x00" in data
+
+
+def bom_text_encoding(data):
+    """Return the Python codec for a BOM-declared UTF-16/UTF-32 file, else None.
+
+    The plain "utf-16" / "utf-32" codecs consume the BOM and auto-select the
+    endianness from it. UTF-32 is checked first (see _UTF32_BOMS).
+    """
+    if data.startswith(_UTF32_BOMS):
+        return "utf-32"
+    if data.startswith(_UTF16_BOMS):
+        return "utf-16"
+    return None
+
+
+def scan_text(path, text, findings):
+    """Report forbidden code points in decoded text with 1-based line:col."""
+    line = 1
+    col = 0
+    for ch in text:
+        if ch == "\n":
+            line += 1
+            col = 0
+            continue
+        if ch == "\r":
+            # CRLF: the \r is not a column -- let the following \n advance the
+            # line so reported columns stay correct on Windows-style endings.
+            continue
+        col += 1
+        name = FORBIDDEN.get(ord(ch))
+        if name is not None:
+            findings.append("%s:%d:%d: U+%04X %s" % (path, line, col, ord(ch), name))
+
+
 def main():
     findings = []
     for path in tracked_files():
         try:
-            with open(path, "r", encoding="utf-8") as fh:
-                lines = fh.readlines()
-        except (UnicodeDecodeError, OSError):
-            # Binary file (vendor .so, image, ...) or unreadable -- skip.
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except IsADirectoryError:
+            # Tracked symlink that points at a directory (e.g. the macOS
+            # .framework internals under thirdparty/) -- not a scannable file.
             continue
-        for lineno, line in enumerate(lines, start=1):
-            for col, ch in enumerate(line, start=1):
-                name = FORBIDDEN.get(ord(ch))
-                if name is not None:
-                    findings.append("%s:%d:%d: U+%04X %s" % (path, lineno, col, ord(ch), name))
+        except OSError as e:
+            # A tracked file we cannot read (broken symlink, bad perms) is a
+            # hard finding -- a security scanner must not pass files it never
+            # inspected, so this fails the job rather than being skipped.
+            findings.append("%s: unreadable tracked file (%s)" % (path, e))
+            continue
+
+        if looks_binary(data):
+            continue
+
+        # UTF-8 is the tree's canonical encoding; decode for precise locations.
+        try:
+            scan_text(path, data.decode("utf-8"), findings)
+            continue
+        except UnicodeDecodeError:
+            pass
+
+        # Not valid UTF-8 but not binary. Honour a declared UTF-16/UTF-32 BOM.
+        enc = bom_text_encoding(data)
+        if enc is not None:
+            try:
+                scan_text(path, data.decode(enc), findings)
+                continue
+            except UnicodeDecodeError:
+                pass
+
+        # Undecodable text: do NOT silently skip (that was the old bypass).
+        # Flag the anomaly and byte-scan for forbidden sequences as a backstop.
+        findings.append("%s: non-UTF-8 text file (cannot verify cleanly; treat as suspect)" % path)
+        for seq, hits in FORBIDDEN_BYTES.items():
+            if seq in data:
+                for cp, enc in hits:
+                    findings.append("%s: contains %s-encoded U+%04X %s" % (path, enc, cp, FORBIDDEN[cp]))
 
     if findings:
         print("Forbidden Unicode characters found:\n")
         for f in findings:
             print("  " + f)
-        print("\n%d occurrence(s). See CVE-2021-42574 (Trojan Source)." % len(findings))
+        print("\n%d finding(s). See CVE-2021-42574 (Trojan Source)." % len(findings))
         return 1
 
     print("Unicode scan OK -- no forbidden characters.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,12 @@ jobs:
           set -euo pipefail
           git fetch --no-tags origin "$GITHUB_BASE_REF"
           merge_base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
+          # git-clang-format --diff exits non-zero when it finds differences.
+          # `|| true` keeps `set -e` from aborting at this assignment so the
+          # check below runs and prints the diff + fix hint, instead of the job
+          # dying with a bare "exit 1" and no actionable output.
           diff="$(git-clang-format --commit "$merge_base" --diff \
-            --extensions c,cc,cpp,cxx,h,hh,hpp,hxx)"
+            --extensions c,cc,cpp,cxx,h,hh,hpp,hxx)" || true
           if [ "$diff" != "no modified files to format" ] && \
              [ "$diff" != "clang-format did not modify any files" ]; then
             echo "$diff"
@@ -390,12 +394,24 @@ jobs:
 
       - name: Install zizmor
         # Prebuilt arm64 release binary — no Rust toolchain / pip build needed.
+        # The tarball is checksum-verified before it runs: a security-audit job
+        # must not itself execute an unverified download. Bump both `ver` and
+        # `sha256` together when upgrading (GitHub release assets are immutable,
+        # so the hash is stable for a given version).
         run: |
           set -euo pipefail
           ver=1.25.2
+          sha256=4b4b9491112c2a09b318101c0d3349b73af1c4f532e097dd6d0164f2abda760d
           curl -fsSL "https://github.com/zizmorcore/zizmor/releases/download/v${ver}/zizmor-aarch64-unknown-linux-gnu.tar.gz" \
             -o /tmp/zizmor.tgz
+          echo "${sha256}  /tmp/zizmor.tgz" | sha256sum --check --strict -
           tar -xzf /tmp/zizmor.tgz -C /tmp
+          # Fail explicitly if a future release changes the archive layout,
+          # rather than relying on `install` to error on a missing path.
+          if [ ! -x /tmp/zizmor ]; then
+            echo "::error::zizmor binary not found at /tmp/zizmor after extraction (archive layout changed?)"
+            exit 1
+          fi
           sudo install /tmp/zizmor /usr/local/bin/zizmor
           zizmor --version
 


### PR DESCRIPTION
Ports the fixes developed across the **openastro-guider PR #3** review so the three repos stay consistent.

## Changes
- **format job — `set -e` abort (real bug).** `git-clang-format --diff` exits non-zero when it finds differences, so under `set -euo pipefail` the `diff="$(…)"` assignment aborted the step *before* the `if` block. On a genuine formatting failure the job died with a bare "exit 1" — the diff and the "fix locally with…" hint never printed. Added `|| true` so the check runs and surfaces the diff + `::error::`.
- **zizmor — checksum-verified download.** The tarball is now verified with `sha256sum --check --strict` (pinned `4b4b9491…da760d`, the published aarch64 asset) before it executes, with an explicit guard if the archive layout changes. A security-audit job shouldn't run an unverified binary.
- **check-unicode.py — close the silent-skip bypass.** No longer skips files it can't decode as UTF-8 (a bidi/zero-width payload in a UTF-16 / invalid-UTF-8 file used to slip through). Now decodes UTF-8 + BOM-declared UTF-16/UTF-32, byte-scans undecodable text as a backstop, treats an unreadable tracked file as a hard finding, and fixes off-by-one columns on CRLF files. The `AlpacaCore/external/` vendored-SDK exclusion is preserved.

## Verified locally
- scanner clean on the tree (vendored `external/` still excluded)
- `ci.yml` parses; zizmor reports no findings
- pinned sha256 matches the published aarch64 tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)