### PR TITLE
ci: skip Claude review on Dependabot and fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,14 @@ concurrency:
 
 jobs:
   review:
+    # CLAUDE_CODE_OAUTH_TOKEN is a repository secret, which GitHub withholds from
+    # Dependabot-triggered and fork-triggered pull_request runs as a security
+    # boundary. Without the token the claude-code-action can't authenticate and
+    # the job fails spuriously. Skip the review in those cases (it is not a
+    # required status check; a maintainer reviews bot and fork PRs by hand).
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The `Claude Code Review` workflow (`claude-review.yml`) fails on **every** Dependabot and fork PR because GitHub withholds repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`) from those runs as a security boundary — so the action can't authenticate and the `review` check shows a spurious ✗ (e.g. Dependabot #74).
- Guard the `review` job so it **skips** (rather than fails) when the token won't be available.

## Changes
- **CI** (`.github/workflows/claude-review.yml`): add a job-level `if:` that runs the review only when the actor is not `dependabot[bot]` **and** the PR head is not a fork:
  ```yaml
  if: >-
    github.actor != 'dependabot[bot]'
    && github.event.pull_request.head.repo.full_name == github.repository
  ```
  The check now reports **skipped** on bot/fork PRs instead of a misleading failure.

## Notes
- `review` is **not** a required status check (main requires the build/test/sanitizer/lint jobs only), so this never blocked merges — it was purely noisy. This stops the noise.
- Trade-off: fork PRs from external contributors no longer get the automated Claude review (a maintainer reviews them by hand). This is intentional — fork `pull_request` runs can't access the token regardless.

## Test plan
- [x] Local pre-flight green, including the `zizmor` workflow audit on the changed file ("No findings to report").
- [x] YAML validated; `if:` expression parses to the intended condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)