### PR TITLE
Vendor ASCOM Alpaca API spec and codify versioning policy in skills

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -125,11 +125,15 @@ Driver Notes format:
 Every commit that changes code or adds features should have a corresponding `CHANGELOG.md` entry. The project uses [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 1. Read the current `CHANGELOG.md` to find the active UNRELEASED section
-2. If no UNRELEASED section exists, create one at the top (below the header):
-   ```
-   ## [x.x.x] - UNRELEASED
-   ```
-   Increment the version from the last released version (patch for fixes, minor for features, major for breaking changes).
+2. Set the UNRELEASED version per the **Versioning policy** below.
+   - If no UNRELEASED section exists, create one at the top (below the header):
+     ```
+     ## [x.x.x] - UNRELEASED
+     ```
+     with the version computed from the last **released** version + this change's bump level.
+   - If an UNRELEASED section already exists, ensure its version is **at least** the bump this
+     change warrants — **upgrade, never downgrade**. (e.g. UNRELEASED is `[2.0.1]` from earlier
+     docs changes and you're now committing a new driver → relabel the heading to `[2.1.0]`.)
 3. Add entries under the appropriate subsection within the UNRELEASED block:
    - `### Added` — new drivers, new features, new files
    - `### Changed` — modifications to existing functionality
@@ -160,6 +164,32 @@ Use component-tagged bullet points matching the project style:
 - **Group related changes** under one bullet with sub-points for complex entries (see existing entries for style)
 - **Don't duplicate**: if an entry for this driver/feature already exists in UNRELEASED, update it rather than adding a new one
 - If the current UNRELEASED section already has the right version number, add to it — don't create a new one
+
+### Versioning policy (Semantic Versioning)
+
+AlpacaBridge is an end-user appliance, so "breaking" means **breaks an existing user's install/
+setup**, not a code-API break. Bump relative to the last **released** version:
+
+| Bump | When | Examples |
+|------|------|----------|
+| **MAJOR** `x.0.0` | Breaks an existing user | Drop a platform (amd64 → 2.0.0), remove a driver, config-format change needing migration, change a default that alters behavior |
+| **MINOR** `x.Y.0` | New backward-compatible capability (resets patch to 0) | **A new driver**, new device/model support, a new optional feature/flag |
+| **PATCH** `x.y.Z` | No new capability | Bug fix to an existing driver, ConformU re-validation, packaging fix, docs/skill/spec changes |
+
+Quick test: **broke** an existing user → major; **added** something new → minor; **fixed/
+polished** what already existed → patch.
+
+**Cumulative carry-forward.** The UNRELEASED version reflects the **highest-severity** change
+accumulated since the last release. A new driver is always a minor bump, never a patch —
+e.g. `2.0.0` → docs `2.0.1` → (later) driver `2.1.0` (minor resets patch, not `2.0.2`) → docs
+`2.1.1`. Within one UNRELEASED cycle, only ever raise the version, never lower it.
+
+**`/commit` touches only `CHANGELOG.md` for versioning** — it sets the `UNRELEASED` heading and
+nothing else. Do **not** modify the `VERSION` file or the `#### [x.x.x] - …` version badge in
+`README.md` in this flow. Those are release actions: `/submit-pr` asks whether to bump them when
+a release is being cut. `VERSION` is the canonical version read by `scripts/build_deb.sh`. If you
+notice `VERSION` or the README badge disagrees with what a release should be, flag it for the
+user — don't silently edit it here.
 
 ## Step 6 — Stage the right files
 

--- a/.claude/commands/driver-build.md
+++ b/.claude/commands/driver-build.md
@@ -31,17 +31,20 @@ Run this check:
 SPEC_LOCAL="docs/AlpacaDeviceAPI_v1.yaml"
 SPEC_URL="https://www.ascom-standards.org/api/AlpacaDeviceAPI_v1.yaml"
 SPEC_REMOTE="$(mktemp)"
+trap 'rm -f "$SPEC_REMOTE"' EXIT   # always clean up the temp download
 
 # Fetch the live spec. If the site is unreachable, warn and proceed with the vendored copy.
 if ! curl -fsSL "$SPEC_URL" -o "$SPEC_REMOTE"; then
   echo "WARN: could not reach $SPEC_URL — proceeding with the existing vendored spec."
 elif [ ! -f "$SPEC_LOCAL" ]; then
-  echo "No vendored spec found — installing the upstream copy."
+  # No vendored copy yet — install it, normalizing CRLF→LF to match the repo (.gitattributes).
+  tr -d '\r' < "$SPEC_REMOTE" > "$SPEC_LOCAL"
+  echo "No vendored spec found — installed the upstream copy at $SPEC_LOCAL."
 # Compare content only, ignoring line endings: the repo stores the spec as LF (.gitattributes
 # `* text=auto eol=lf`) but ascom-standards.org serves CRLF, so a raw cmp would always report a
 # false difference. --strip-trailing-cr makes the check line-ending-insensitive.
 elif diff -q --strip-trailing-cr "$SPEC_LOCAL" "$SPEC_REMOTE" >/dev/null; then
-  echo "ASCOM Alpaca spec is CURRENT ($(grep -m1 -E '^  version:' "$SPEC_LOCAL" | tr -d ' \r'))."
+  echo "ASCOM Alpaca spec is CURRENT (version $(grep -m1 -E '^  version:' "$SPEC_LOCAL" | sed 's/.*version:[[:space:]]*//; s/\r$//'))."
 else
   echo "Spec DIFFERS from upstream — classifying the change:"
   echo "--- info (title/version) ---"
@@ -59,9 +62,10 @@ fi
 - **No difference** → spec is current. Note the version and continue to Step 1.
 - **Major change** — the `version:` field changed, OR the endpoint set changed (any `<`/`>`
   lines in the path diff), OR the operation count changed. Treat this as a real spec revision:
-  1. Download the updated file over the vendored copy:
+  1. Write the already-fetched remote over the vendored copy, normalizing CRLF→LF so the working
+     tree stays LF (matching `.gitattributes`) — reuse `$SPEC_REMOTE`, don't re-download:
      ```bash
-     curl -fsSL "$SPEC_URL" -o docs/AlpacaDeviceAPI_v1.yaml
+     tr -d '\r' < "$SPEC_REMOTE" > docs/AlpacaDeviceAPI_v1.yaml
      ```
   2. Show the user a short summary of what changed (version bump, added/removed endpoints,
      affected device types) and call out anything that touches the device type they're about
@@ -69,8 +73,9 @@ fi
   3. The updated `docs/AlpacaDeviceAPI_v1.yaml` will be committed on the driver's feature
      branch as part of this session (mention it in the plan summary in Step 1).
 - **Minor/cosmetic change only** (wording in `description:`/`summary:` lines, no endpoint or
-  version change) → still refresh the vendored copy with the `curl` command above so it stays
-  byte-identical to upstream, but note it as non-breaking.
+  version change) → still refresh the vendored copy with the same `tr -d '\r' < "$SPEC_REMOTE" >
+  docs/AlpacaDeviceAPI_v1.yaml` command so it stays content-identical to upstream (LF-normalized),
+  but note it as non-breaking.
 
 Do not skip this step even when the user passes a vendor + device type as arguments — the spec
 check always runs first.

--- a/.claude/commands/driver-build.md
+++ b/.claude/commands/driver-build.md
@@ -14,6 +14,67 @@ The user invoked this command with: $ARGUMENTS
 - If arguments include only a vendor name, skip the vendor question in Step 1 but still present the device type menu.
 - If no arguments are provided, start from the top of Step 1.
 
+## Step 0 — Verify the ASCOM Alpaca API spec is current (run first, EVERY time)
+
+Before asking any questions or writing any code, confirm the project's vendored copy of the
+ASCOM Alpaca API specification matches the live spec published by ASCOM. The vendored copy is
+the source of truth that Step 3 builds against — if it has drifted from upstream, every driver
+built this session would be aligned to a stale contract.
+
+- **Vendored spec:** `docs/AlpacaDeviceAPI_v1.yaml`
+- **Upstream spec:** `https://www.ascom-standards.org/api/AlpacaDeviceAPI_v1.yaml`
+  (this is the raw OpenAPI YAML behind the Swagger UI at https://ascom-standards.org/api/)
+
+Run this check:
+
+```bash
+SPEC_LOCAL="docs/AlpacaDeviceAPI_v1.yaml"
+SPEC_URL="https://www.ascom-standards.org/api/AlpacaDeviceAPI_v1.yaml"
+SPEC_REMOTE="$(mktemp)"
+
+# Fetch the live spec. If the site is unreachable, warn and proceed with the vendored copy.
+if ! curl -fsSL "$SPEC_URL" -o "$SPEC_REMOTE"; then
+  echo "WARN: could not reach $SPEC_URL — proceeding with the existing vendored spec."
+elif [ ! -f "$SPEC_LOCAL" ]; then
+  echo "No vendored spec found — installing the upstream copy."
+# Compare content only, ignoring line endings: the repo stores the spec as LF (.gitattributes
+# `* text=auto eol=lf`) but ascom-standards.org serves CRLF, so a raw cmp would always report a
+# false difference. --strip-trailing-cr makes the check line-ending-insensitive.
+elif diff -q --strip-trailing-cr "$SPEC_LOCAL" "$SPEC_REMOTE" >/dev/null; then
+  echo "ASCOM Alpaca spec is CURRENT ($(grep -m1 -E '^  version:' "$SPEC_LOCAL" | tr -d ' \r'))."
+else
+  echo "Spec DIFFERS from upstream — classifying the change:"
+  echo "--- info (title/version) ---"
+  diff --strip-trailing-cr <(grep -E "^  (title|version):" "$SPEC_LOCAL") \
+                           <(grep -E "^  (title|version):" "$SPEC_REMOTE") || true
+  echo "--- endpoint set (added '>' / removed '<' = MAJOR change) ---"
+  diff <(grep -oE "^  '/[^']+'" "$SPEC_LOCAL" | sort) \
+       <(grep -oE "^  '/[^']+'" "$SPEC_REMOTE" | sort) || true
+  echo "--- HTTP-operation count: local=$(grep -cE '^    (get|put|post):' "$SPEC_LOCAL") remote=$(grep -cE '^    (get|put|post):' "$SPEC_REMOTE") ---"
+fi
+```
+
+**Classify and act:**
+
+- **No difference** → spec is current. Note the version and continue to Step 1.
+- **Major change** — the `version:` field changed, OR the endpoint set changed (any `<`/`>`
+  lines in the path diff), OR the operation count changed. Treat this as a real spec revision:
+  1. Download the updated file over the vendored copy:
+     ```bash
+     curl -fsSL "$SPEC_URL" -o docs/AlpacaDeviceAPI_v1.yaml
+     ```
+  2. Show the user a short summary of what changed (version bump, added/removed endpoints,
+     affected device types) and call out anything that touches the device type they're about
+     to build.
+  3. The updated `docs/AlpacaDeviceAPI_v1.yaml` will be committed on the driver's feature
+     branch as part of this session (mention it in the plan summary in Step 1).
+- **Minor/cosmetic change only** (wording in `description:`/`summary:` lines, no endpoint or
+  version change) → still refresh the vendored copy with the `curl` command above so it stays
+  byte-identical to upstream, but note it as non-breaking.
+
+Do not skip this step even when the user passes a vendor + device type as arguments — the spec
+check always runs first.
+
 ## Step 1 — Ask the user what they are building
 
 Before writing any code, ask the user the following questions **one at a time**. Wait for each answer before asking the next.
@@ -200,22 +261,34 @@ Every new `.h`, `.hpp`, `.cpp` file must include the SSPL v1 license header. Cop
 
 ### ASCOM Alpaca API compliance (non-negotiable)
 
-The driver MUST implement the official ASCOM Alpaca API specification exactly. The spec is the contract — every property, method, return type, error code, and behavior must match.
+The driver MUST implement the official ASCOM Alpaca API specification **exactly — to the letter**. The spec is the contract: every property, method, parameter, return type, value range, error code, and behavior must match. Following the API "to a T" is non-negotiable — this is what keeps every AlpacaBridge driver aligned with ASCOM Alpaca and passing ConformU.
 
-**Primary reference**: https://ascom-standards.org/api/#/
+**Primary reference (source of truth)**: the vendored spec at `docs/AlpacaDeviceAPI_v1.yaml`, which Step 0 just verified is current. Read it directly — do not work from memory of the API.
 
-Before writing any code, use WebFetch to load the API page for the device type being implemented and review every method and property. The device-type API sections are:
+**Human-readable cross-check (optional)**: https://ascom-standards.org/api/#/ renders the same spec in Swagger UI if you want to browse it visually.
 
-- Camera: `ASCOM Methods Common to all devices` + `Camera Specific Methods`
-- CoverCalibrator: common + `CoverCalibrator Specific Methods`
-- Dome: common + `Dome Specific Methods`
-- FilterWheel: common + `FilterWheel Specific Methods`
-- Focuser: common + `Focuser Specific Methods`
-- ObservingConditions: common + `ObservingConditions Specific Methods`
-- Rotator: common + `Rotator Specific Methods`
-- SafetyMonitor: common + `SafetyMonitor Specific Methods`
-- Switch: common + `Switch Specific Methods`
-- Telescope: common + `Telescope Specific Methods`
+Before writing any code, extract the exact contract for the device type from the vendored YAML. The common endpoints (every device implements these) use `/{device_type}/...`; the device-specific endpoints use `/<devicetype>/...`:
+
+```bash
+DEV=filterwheel   # lowercase device type being built
+# Every endpoint this driver must implement (common + device-specific):
+grep -oE "^  '/[^']+'" docs/AlpacaDeviceAPI_v1.yaml | grep -E "^  '/(\{device_type\}|$DEV)/"
+```
+
+For each endpoint, open the relevant section of `docs/AlpacaDeviceAPI_v1.yaml` and read the HTTP verb, parameters, value ranges, response schema, and the documented error behavior. Implement against exactly what the YAML says — parameter names, casing, ranges, and the NotImplemented/NotConnected/InvalidValue semantics are all part of the contract.
+
+The device-type API surfaces are:
+
+- Camera: common methods + `Camera`-specific endpoints
+- CoverCalibrator: common + `CoverCalibrator`-specific endpoints
+- Dome: common + `Dome`-specific endpoints
+- FilterWheel: common + `FilterWheel`-specific endpoints (`names`, `focusoffsets`, `position`)
+- Focuser: common + `Focuser`-specific endpoints
+- ObservingConditions: common + `ObservingConditions`-specific endpoints
+- Rotator: common + `Rotator`-specific endpoints
+- SafetyMonitor: common + `SafetyMonitor`-specific endpoints
+- Switch: common + `Switch`-specific endpoints
+- Telescope: common + `Telescope`-specific endpoints
 
 Key compliance rules:
 - **Every property and method** listed in the API for the device type must be implemented. If the hardware doesn't support a capability, the method must still exist and throw the appropriate ASCOM error (e.g., `PropertyNotImplemented`, `NotConnected`, `InvalidValue`).
@@ -228,7 +301,12 @@ Key compliance rules:
 
 When in doubt about a behavior, check the spec first, then check how existing drivers in this project handle it, then check INDI/INDIGO for reference.
 
-### Use an existing driver as a template
+### Use an existing driver as a template (cross-driver consistency)
+
+Always study the existing drivers of the **same device type** before writing a new one, and
+match their structure, naming, and behavior so every driver of a given type behaves the same
+way. The ASCOM spec defines *what* the contract is; the existing drivers define *how this
+project* satisfies it. New drivers must not invent a divergent shape.
 
 Find the closest matching existing driver for the same device type:
 
@@ -236,6 +314,23 @@ Find the closest matching existing driver for the same device type:
 ls AlpacaCore/src/vendors/*/
 ls AlpacaCore/include/alpacacore/vendor/*/
 ```
+
+**FilterWheel consistency (important).** All filter wheel drivers must share the same filter
+setup and UI as the existing ones — use the **ZWO EFW** (`zwo_filterwheel_driver`) and **Player
+One Phoenix Wheel** drivers as the canonical templates. Specifically match:
+- the slot-count handling and the default/standard filter name set,
+- `Names` and `FocusOffsets` semantics (array length tied to slot count, defaults, persistence),
+- the web UI slot lineup built with `createFilterwheelSlotUI({...})` (see Step 6 and AGENTS.md).
+
+A new filter wheel should differ from ZWO/Player One only where the hardware genuinely differs
+(slot counts offered, enumeration/SDK details) — never in how filters are named, stored, or
+presented. The same "match the existing drivers" rule applies to every device type (cameras
+follow the ZWO/QHY/SVBONY shape, telescopes follow iOptron/SynScan, etc.), but filter wheels
+are the most common place divergence slips in.
+
+Reconcile both sources: where an existing driver and the spec appear to disagree, the spec
+(`docs/AlpacaDeviceAPI_v1.yaml`) wins — and that likely means the existing driver has a bug to
+fix across all drivers, per the project's "fix shared patterns everywhere" rule.
 
 ### Required runtime semantics
 - Async `connect()/disconnect()` with `get_connecting()`.

--- a/.claude/commands/submit-pr.md
+++ b/.claude/commands/submit-pr.md
@@ -110,13 +110,53 @@ Review the branch contents and warn the user about anything that's missing:
 
 - [ ] **Unit tests**: Does the branch include Catch2 tests? (required for all driver code)
 - [ ] **ConformU results**: If this is a driver PR, is an arm64 ConformU report included AND clean (verified in Step 1 — errors=0, issues=0, timing issues=0)?
-- [ ] **CHANGELOG.md**: Is there an entry under `## [x.x.x] - UNRELEASED`?
+- [ ] **CHANGELOG.md**: Is there an entry under `## [x.x.x] - UNRELEASED`, and does the version match the **Versioning policy** below for everything on this branch?
 - [ ] **SUPPORTED-DRIVERS.md**: If this adds or validates a driver, is the table updated?
 - [ ] **AGENTS.md**: Were lessons learned captured?
 - [ ] **SSPL license headers**: Do new source files have the license header?
 - [ ] **SDK cleanup**: If SDK files were added under `external/`, have Windows/macOS/32-bit/demo files been removed?
 
 Present the checklist to the user with pass/fail status. If critical items are missing (tests, CHANGELOG), recommend fixing before submitting but let the user decide.
+
+### Verify the UNRELEASED version (Versioning policy)
+
+Look at everything this branch adds/changes (from the diff above) and confirm the
+`## [x.x.x] - UNRELEASED` heading in `CHANGELOG.md` reflects the **highest-severity** change.
+AlpacaBridge is an end-user appliance, so "breaking" means breaks an existing user's install/
+setup. Bump relative to the last **released** version:
+
+- **MAJOR** `x.0.0` — breaks an existing user (drop a platform, remove a driver, config-format
+  change needing migration, change a default that alters behavior).
+- **MINOR** `x.Y.0` — new backward-compatible capability: **a new driver**, new device/model
+  support, a new optional feature/flag. Resets patch to 0.
+- **PATCH** `x.y.Z` — no new capability: bug fix to an existing driver, ConformU re-validation,
+  packaging fix, docs/skill/spec changes.
+
+A branch that adds a new driver MUST be a minor bump, never a patch. If the UNRELEASED heading
+undershoots (e.g. it says `2.0.1` but the branch adds a driver, so it should be `2.1.0`), flag
+it and recommend running `/commit` to correct the heading before opening the PR — don't open a
+PR with a version that misrepresents the change.
+
+### Release version bump (ask the user)
+
+Most PRs leave the version as `UNRELEASED` and the actual release is cut separately. Before
+pushing, ask the user whether this PR is cutting the release:
+
+> "Is this PR cutting the `<UNRELEASED version>` release? If so I can update the `VERSION` file
+> and the `README.md` version badge to `<UNRELEASED version>` (and date the CHANGELOG entry) so
+> they're ready for release. Otherwise I'll leave everything as UNRELEASED."
+
+- **If NO** (default for feature / driver / fix PRs) — leave the `VERSION` file, the `README.md`
+  badge, and the CHANGELOG `UNRELEASED` heading untouched. Proceed to Step 4.
+- **If YES** — finalize the version (the `[x.x.x]` from the CHANGELOG UNRELEASED heading):
+  1. Write the bare version (e.g. `2.1.0`) into the `VERSION` file — `printf '%s\n' <version> > VERSION`.
+  2. Update the README badge line `#### [x.x.x] - YYYY-MM-DD &middot; [Changelog](CHANGELOG.md)`
+     to the new version and **today's date**.
+  3. Change the CHANGELOG heading `## [x.x.x] - UNRELEASED` to `## [x.x.x] - YYYY-MM-DD` (today),
+     so `VERSION`, the README badge, and the CHANGELOG agree.
+  4. These are now uncommitted changes (Step 1 required a clean tree). Show the user the diff and
+     a commit message (e.g. `Release <version>`) for approval, commit them on this branch
+     following the project's commit conventions, then continue to the Step 4 pre-flight and push.
 
 ## Step 4 — Local CI pre-flight (HARD BLOCK)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
+## [2.0.1] - UNRELEASED
+
+### Added
+- **Vendored ASCOM Alpaca API spec** (docs): the upstream OpenAPI YAML behind https://ascom-standards.org/api/ is now committed at `docs/AlpacaDeviceAPI_v1.yaml` (OpenAPI 3.1.1, MIT-licensed) as the in-repo source of truth for driver development.
+
+### Changed
+- **`/driver-build` skill**: added Step 0 that verifies the vendored ASCOM Alpaca spec is current against ascom-standards.org on every run (diffs version/endpoints, re-downloads on major changes); Step 3 now drives off the vendored `docs/AlpacaDeviceAPI_v1.yaml` to follow the API exactly; reinforced cross-driver consistency (filter wheels match ZWO EFW / Player One Phoenix setup).
+- **`/commit` skill**: documented the project Semantic Versioning policy (driver=minor, fix/docs=patch, breaking=major) with cumulative carry-forward; `/commit` now only sets the CHANGELOG `UNRELEASED` heading and never edits `VERSION` or the README badge.
+- **`/submit-pr` skill**: verifies the UNRELEASED version matches the versioning policy for the branch, and asks whether the PR is cutting a release — offering to bump the `VERSION` file and `README.md` version badge (and date the CHANGELOG entry) when it is.
+
 ## [2.0.0] - 2026-06-13
 
 ### Added

--- a/docs/AlpacaDeviceAPI_v1.yaml
+++ b/docs/AlpacaDeviceAPI_v1.yaml
@@ -1,0 +1,6356 @@
+openapi: 3.1.1
+
+## This file is licensed under the MIT license, SPDX identifier: MIT
+
+## Copyright (c) 2025 ASCOM Initiative, Peter Simpson, Bob Denny, Danial Van Noord
+
+## Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+## associated documentation files (the "Software"), to deal in the Software without restriction, 
+## including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+## and/or sell copies of the Software, and to permit persons to whom the Software is furnished to 
+## do so, subject to the following conditions:
+
+## The above copyright notice and this permission notice (including the next paragraph) shall be 
+## included in all copies or substantial portions of the Software.
+
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
+## BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+## IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+## WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+
+info:
+  title: ASCOM Alpaca Device API
+  
+  version: v1
+  
+  license:
+    name: MIT
+    url: https://opensource.org/license/mit
+
+  description: >
+    The Alpaca API uses RESTful techniques and TCP/IP to enable ASCOM applications and devices to communicate across modern network environments.
+
+
+    ## Interface Versions
+
+    These interface definitions include the updates introduced in **ASCOM Platform 7**.
+
+
+    ## Interface Behaviour
+
+    The ASCOM Interface behavioural requirements for Alpaca drivers are the same as for COM based drivers and are documented in the
+    <a href="https://ascom-standards.org/newdocs/">API Master Interface Definitions</a> e.g.
+    the <a href="https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToCoordinatesAsync">Telescope.SlewToCoordinatesAsync</a> method.      
+    This document focuses on how to use the ASCOM Interface standards in their RESTful Alpaca form.
+    
+    ## Try it out
+    
+    `April 2025` - The "Try it out" option has been removed from this online API definition becuase the experience was poor compared to
+    using "Try it out" in the Omni-Simulators, which are installed as part of Platform 7. 
+    
+    You can view the Omni-Simulator's Alpaca API descriptions, including "Try it out", by starting the Omni-Simulators and clicking the "View Swagger docs and interactive queries" link on the home page.
+    
+    
+    ## Alpaca URLs, Case Sensitivity, Parameters and Returned values
+
+    **Alpaca Device API URLs** are of the form **http(s)://host:port/path** where path comprises **"/api/v1/"** followed by one of the method names below.
+    e.g. for an Alpaca interface running on port 7843 of a device with IP address 192.168.1.89:
+    
+    * A telescope "Interface Version" method URL would be **http://192.168.1.89:7843/api/v1/telescope/0/interfaceversion**
+        
+    * A first focuser "Position" method URL would be  **http://192.168.1.89:7843/api/v1/focuser/0/position**
+        
+    * A second focuser "StepSize" method URL would be  **http://192.168.1.89:7843/api/v1/focuser/1/stepsize**
+
+    * A rotator "Halt" method URL would be  **http://192.168.1.89:7843/api/v1/rotator/0/halt**
+    
+    
+    
+    URLs are case sensitive and all elements must be in lower case. This means that both the device type and command name must always be in lower case. Parameter names are not case sensitive, so clients and drivers should be prepared for parameter names to be supplied and returned with any casing. Parameter values can be in mixed case as required.
+    
+    
+    For GET operations, parameters should be placed in the URL query string and for PUT operations they should be placed in the body of the message.
+
+
+    Responses, as described below, are returned in JSON format and always include a common set of values including the client's transaction number, 
+    the server's transaction number together with any error message and error number.
+
+    If the transaction completes successfully, the ErrorMessage field will be an empty string and the ErrorNumber field will be zero.
+
+
+    ## HTTP Status Codes and ASCOM Error codes
+
+    The returned HTTP status code gives a high level view of whether the device understood the request and whether it attempted to process it.
+    
+    
+    Under most circumstances the returned status will be `200`, indicating that the request was correctly formatted and that it was passed to the device's handler to execute.
+    A `200` status does not necessarily mean that the operation completed as expected, without error, and you must always check the ErrorMessage and ErrorNumber fields to confirm
+    whether the returned result is valid. The `200` status simply means that the transaction was successfully managed by the device's transaction management layer.
+    
+    
+    An HTTP status code of `400` indicates that the device could not interpret the request e.g. an invalid device number or misspelt device type was supplied. Check the body of the response for a text error message.
+
+
+    An HTTP status code of `500` indicates an unexpected error within the device from which it could not recover. Check the body of the response for a text error message.
+
+    ## SetupDialog and Alpaca Device Configuration
+
+    The SetupDialog method has been omitted from the Alpaca Device API because it presents a user interface rather than returning data. Alpaca device configuration is covered in the "ASCOM Alpaca Management API" specification, which can be selected through the drop-down box at the head of this page.
+    
+    ## Copyright and License
+    
+    Copyright (c) 2025 ASCOM Initiative, Peter Simpson, Bob Denny, Danial Van Noord
+    
+# This API has no security features
+security: []
+
+paths:
+  '/{device_type}/{device_number}/action':
+    put:
+      summary: Invokes the named device-specific action. 
+      description:  >-
+        Actions and SupportedActions are a standardised means for drivers to extend functionality beyond the built-in capabilities of the ASCOM device interfaces.
+        
+        
+        The key advantage of using Actions is that drivers can expose any device specific functionality required. The downside is that, in order to use these unique features, every application author would need to create bespoke code to present or exploit them.
+        
+        
+        The Action parameter and return strings are deceptively simple, but can support transmission of arbitrarily complex data structures, for example through JSON encoding.
+        
+        
+        This capability will be of primary value to:
+         * bespoke software and hardware configurations where a single entity controls both the consuming application software and the hardware / driver environment
+         * a group of application and device authors who want to quickly formulate and try out new interface capabilities without requiring an immediate change to the ASCOM device interface, which will take a lot longer than just agreeing a name, input parameters and a standard response for an Action command
+        
+        
+        The list of Action commands supported by a driver can be discovered through the SupportedActions property.
+        
+        
+        This method should return an error message and NotImplementedException error number (0x400) if the driver just implements the standard ASCOM device methods and has no bespoke, unique, functionality.
+        
+        
+        See this link for the canonical definition, which may include further information and implementation requirements: [Action](https://ascom-standards.org/newdocs/camera.html#Camera.Action)". Please note that the camera definition in the link applies to all device types.
+
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Action:
+                      description: A well known name that represents the action to be carried out.
+                      type: string
+                    Parameters:
+                      description: List of required parameters or an Empty String if none are required
+                      type: string
+                  required:
+                    - Action
+                    - Parameters
+  '/{device_type}/{device_number}/commandblind':
+    put:
+      summary: Transmits an arbitrary string to the device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CommandBlind](https://ascom-standards.org/newdocs/camera.html#Camera.CommandBlind). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandrequest'
+  '/{device_type}/{device_number}/commandbool':
+    put:
+      summary: Transmits an arbitrary string to the device and returns a boolean value from the device.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CommandBool](https://ascom-standards.org/newdocs/camera.html#Camera.CommandBool). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandrequest'
+  '/{device_type}/{device_number}/commandstring':
+    put:
+      summary: Transmits an arbitrary string to the device and returns a string value from the device.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CommandString](https://ascom-standards.org/newdocs/camera.html#Camera.CommandString). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/put_devicetype_Devicenumber_commandrequest'
+  '/{device_type}/{device_number}/connect':
+    put:
+      summary: Starts an asynchronous connect to the device.
+      description: "`Platform 7 onward.` See this link for the canonical definition, which may include further information and implementation requirements: [Connect](https://ascom-standards.org/newdocs/camera.html#Camera.Connect). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/{device_type}/{device_number}/connected':
+    get:
+      summary: Retrieves the connected state of the device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Connected](https://ascom-standards.org/newdocs/camera.html#Camera.Connected). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the connected state of the device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Connected](https://ascom-standards.org/newdocs/camera.html#Camera.Connected). Please note that the camera definition in the link applies to all device types."
+      tags:
+        - ASCOM Methods Common To All Devices
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Connected:
+                      description: >-
+                        Set True to connect to the device hardware, set False to
+                        disconnect from the device hardware
+                      type: boolean
+                  required:
+                    - Connected
+  '/{device_type}/{device_number}/connecting':
+    get:
+      summary: Completion variable for the asynchronous Connect() and Disconnect() methods.
+      description: "`Platform 7 onward.` See this link for the canonical definition, which may include further information and implementation requirements: [Connecting](https://ascom-standards.org/newdocs/camera.html#Camera.Connecting). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/description':
+    get:
+      summary: Device description
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Description](https://ascom-standards.org/newdocs/camera.html#Camera.Description). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/devicestate':
+    get:
+      summary: Returns the device's operational state in a single call.
+      description: >-
+        "`Platform 7 onward.` Please note that this member has the same signature in all device interfaces but the returned properties vary by device type:
+        
+        
+        [Camera DeviceState](https://ascom-standards.org/newdocs/camera.html#Camera.DeviceState)
+        
+
+        [CoverCalibrator DeviceState](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.DeviceState)
+        
+
+        [Dome DeviceState](https://ascom-standards.org/newdocs/dome.html#Dome.DeviceState)
+        
+
+        [FilterWheel DeviceState](https://ascom-standards.org/newdocs/filterwheel.html#FilterWheel.DeviceState)
+        
+
+        [Focuser DeviceState](https://ascom-standards.org/newdocs/focuser.html#Focuser.DeviceState)
+        
+
+        [ObservingConditions DeviceState](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.DeviceState)
+        
+
+        [Rotator DeviceState](https://ascom-standards.org/newdocs/rotator.html#Rotator.DeviceState)
+        
+
+        [SafetyMonitor DeviceState](https://ascom-standards.org/newdocs/safetymonitor.html#SafetyMonitor.DeviceState)
+        
+
+        [Switch DeviceState](https://ascom-standards.org/newdocs/switch.html#Switch.DeviceState)
+        
+
+        [Telescope DeviceState](https://ascom-standards.org/newdocs/telescope.html#Telescope.DeviceState)
+        
+
+        See here for more information: [DeviceState FAQ](https://ascom-standards.org/newdocs/readall-faq.html)"
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/DeviceStateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/disconnect':
+    put:
+      summary: Starts an asynchronous disconnect from the device.
+      description: "`Platform 7 onward.` See this link for the canonical definition, which may include further information and implementation requirements: [Disconnect](https://ascom-standards.org/newdocs/camera.html#Camera.Disconnect). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/{device_type}/{device_number}/driverinfo':
+    get:
+      summary: Device driver description
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DriverInfo](https://ascom-standards.org/newdocs/camera.html#Camera.DriverInfo). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/driverversion':
+    get:
+      summary: Driver Version
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DriverVersion](https://ascom-standards.org/newdocs/camera.html#Camera.DriverVersion). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/interfaceversion':
+    get:
+      summary: The ASCOM Device interface version number that this device supports.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [InterfaceVersion](https://ascom-standards.org/newdocs/camera.html#Camera.InterfaceVersion). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/name':
+    get:
+      summary: Device name
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Name](https://ascom-standards.org/newdocs/camera.html#Camera.Name). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/{device_type}/{device_number}/supportedactions':
+    get:
+      summary: Returns the list of action names supported by this driver.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SupportedActions](https://ascom-standards.org/newdocs/camera.html#Camera.SupportedActions). Please note that the camera definition in the link applies to all device types."
+      parameters:
+        - $ref: '#/components/parameters/device_type'
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ASCOM Methods Common To All Devices
+      responses:
+        '200':
+          $ref: '#/components/responses/StringArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+
+  '/camera/{device_number}/bayeroffsetx':
+    get:
+      summary: Returns the X offset of the Bayer matrix.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BayerOffsetX](https://ascom-standards.org/newdocs/camera.html#Camera.BayerOffsetX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/bayeroffsety':
+    get:
+      summary: Returns the Y offset of the Bayer matrix.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BayerOffsetY](https://ascom-standards.org/newdocs/camera.html#Camera.BayerOffsetY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/binx':
+    get:
+      summary: Returns the binning factor for the X axis.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BinX](https://ascom-standards.org/newdocs/camera.html#Camera.BinX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntMinimum1Response'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the binning factor for the X axis.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BinX](https://ascom-standards.org/newdocs/camera.html#Camera.BinX)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    BinX:
+                      description: The X binning value
+                      type: integer
+                      format: int32
+                      example: 1
+                      minimum: 1
+                  required:
+                    - BinX
+  '/camera/{device_number}/biny':
+    get:
+      summary: Returns the binning factor for the Y axis.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BinY](https://ascom-standards.org/newdocs/camera.html#Camera.BinY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntMinimum1Response'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the binning factor for the Y axis.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [BinY](https://ascom-standards.org/newdocs/camera.html#Camera.BinY)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    BinY:
+                      description: The Y binning value
+                      type: integer
+                      format: int32
+                      example: 1
+                      minimum: 1
+                  required:
+                    - BinY
+  '/camera/{device_number}/camerastate':
+    get:
+      summary: Returns the camera operational state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CameraState](https://ascom-standards.org/newdocs/camera.html#Camera.CameraState)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/CameraStateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/cameraxsize':
+    get:
+      summary: Returns the width of the CCD camera chip.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CameraXSize](https://ascom-standards.org/newdocs/camera.html#Camera.CameraXSize)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/cameraysize':
+    get:
+      summary: Returns the height of the CCD camera chip.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CameraYSize](https://ascom-standards.org/newdocs/camera.html#Camera.CameraYSize)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/canabortexposure':
+    get:
+      summary: Indicates whether the camera can abort exposures.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanAbortExposure](https://ascom-standards.org/newdocs/camera.html#Camera.CanAbortExposure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/canasymmetricbin':
+    get:
+      summary: Indicates whether the camera supports asymmetric binning.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanAsymmetricBin](https://ascom-standards.org/newdocs/camera.html#Camera.CanAsymmetricBin)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/canfastreadout':
+    get:
+      summary: Indicates whether the camera has a fast readout mode.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanFastReadout](https://ascom-standards.org/newdocs/camera.html#Camera.CanFastReadout)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/cangetcoolerpower':
+    get:
+      summary: Indicates whether the camera's cooler power setting can be read.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanGetCoolerPower](https://ascom-standards.org/newdocs/camera.html#Camera.CanGetCoolerPower)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/canpulseguide':
+    get:
+      summary: Indicates whether this camera supports pulse guiding.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanPulseGuide](https://ascom-standards.org/newdocs/camera.html#Camera.CanPulseGuide)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/cansetccdtemperature':
+    get:
+      summary: Indicates whether this camera supports setting the CCD temperature.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetCCDTemperature](https://ascom-standards.org/newdocs/camera.html#Camera.CanSetCCDTemperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/canstopexposure':
+    get:
+      summary: Indicates whether this camera can stop an exposure that is in progress.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanStopExposure](https://ascom-standards.org/newdocs/camera.html#Camera.CanStopExposure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/ccdtemperature':
+    get:
+      summary: Returns the current CCD temperature in degrees Celsius
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CCDTemperature](https://ascom-standards.org/newdocs/camera.html#Camera.CCDTemperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/cooleron':
+    get:
+      summary: Returns the current cooler on/off state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CoolerOn](https://ascom-standards.org/newdocs/camera.html#Camera.CoolerOn)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Turns the camera cooler on and off
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CoolerOn](https://ascom-standards.org/newdocs/camera.html#Camera.CoolerOn)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    CoolerOn:
+                      description: Cooler state
+                      type: boolean
+                      example: true
+                  required:
+                    - CoolerOn
+  '/camera/{device_number}/coolerpower':
+    get:
+      summary: Returns the present cooler power level
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CoolerPower](https://ascom-standards.org/newdocs/camera.html#Camera.CoolerPower)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/PercentDoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/electronsperadu':
+    get:
+      summary: Returns the gain of the camera in photoelectrons per A/D unit.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ElectronsPerADU](https://ascom-standards.org/newdocs/camera.html#Camera.ElectronsPerADU)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/exposuremax':
+    get:
+      summary: Returns the maximum exposure time supported by StartExposure.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ExposureMax](https://ascom-standards.org/newdocs/camera.html#Camera.ExposureMax)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/exposuremin':
+    get:
+      summary: Returns the Minimium exposure time supported by StartExposure.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ExposureMin](https://ascom-standards.org/newdocs/camera.html#Camera.ExposureMin)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/exposureresolution':
+    get:
+      summary: Returns the smallest increment in exposure time supported by StartExposure.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ExposureResolution](https://ascom-standards.org/newdocs/camera.html#Camera.ExposureResolution)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/fastreadout':
+    get:
+      summary: Returns whenther Fast Readout Mode is enabled.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FastReadout](https://ascom-standards.org/newdocs/camera.html#Camera.FastReadout)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets whether Fast Readout Mode is enabled.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FastReadout](https://ascom-standards.org/newdocs/camera.html#Camera.FastReadout)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    FastReadout:
+                      description: True to enable fast readout mode
+                      type: boolean
+                      example: false
+                  required:
+                    - FastReadout
+  '/camera/{device_number}/fullwellcapacity':
+    get:
+      summary: Reports the full well capacity of the camera in electrons, at the current camera settings.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FullWellCapacity](https://ascom-standards.org/newdocs/camera.html#Camera.FullWellCapacity)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/gain':
+    get:
+      summary: Returns the camera's gain (GAIN VALUE MODE) OR the index of the selected camera gain description in the Gains array (GAINS INDEX MODE).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Gain](https://ascom-standards.org/newdocs/camera.html#Camera.Gain)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the camera's gain (GAIN VALUE MODE) OR the index of the selected camera gain description in the Gains array (GAINS INDEX MODE).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Gain](https://ascom-standards.org/newdocs/camera.html#Camera.Gain)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Gain:
+                      description: Index of the current camera gain in the Gains string array.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - Gain
+  '/camera/{device_number}/gainmax':
+    get:
+      summary: Maximum Gain value of that this camera supports
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GainMax](https://ascom-standards.org/newdocs/camera.html#Camera.GainMax)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/gainmin':
+    get:
+      summary: Minimum Gain value of that this camera supports 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GainMin](https://ascom-standards.org/newdocs/camera.html#Camera.GainMin)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/gains':
+    get:
+      summary: List of Gain names supported by the camera 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Gains](https://ascom-standards.org/newdocs/camera.html#Camera.Gains)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/hasshutter':
+    get:
+      summary: Indicates whether the camera has a mechanical shutter
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [HasShutter](https://ascom-standards.org/newdocs/camera.html#Camera.HasShutter)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/heatsinktemperature':
+    get:
+      summary: Returns the current heat sink temperature in degrees Celsius.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [HeatSinkTemperature](https://ascom-standards.org/newdocs/camera.html#Camera.HeatSinkTemperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/imagearray':
+    get:
+      summary: Returns an array of integers containing the exposure pixel values
+      description: > 
+        Further information here: [ImageArray](https://ascom-standards.org/newdocs/camera.html#Camera.ImageArray)
+        
+
+        ## Alpaca Specific Detail
+        
+        
+        Returns an array of 32bit integers containing the pixel values from the last exposure. This call can return either a 2 dimension (monochrome images) or 3 dimension (colour or multi-plane images) array 
+        of size `NumX * NumY` or `NumX * NumY * NumPlanes`. Where applicable, the size of `NumPlanes` has to be determined by inspection of the returned array.
+
+
+        Since 32bit integers are always returned by this call, the returned JSON `Type` value is always 2 (integer).
+
+
+        When de-serialising to an object it is essential to know the array `Rank` beforehand so that the correct data class can be used. This can be achieved through a regular expression or by direct parsing 
+        of the returned JSON string to extract the `Type` and `Rank` values before de-serialising.
+
+
+        This regular expression accomplishes the extraction into two named groups `Type` and `Rank`, which can then be used to select the correct de-serialisation data class:
+
+
+        `^*"Type":(?<Type>\d*),"Rank":(?<Rank>\d*)`
+
+
+        When the `SensorType` is Monochrome, RGGB, CMYG, CMYG2 or LRGB, the serialised JSON array should have 2 dimensions. For example, the returned array should appear as below if `NumX = 7`, `NumY = 5` 
+        and `Pxy` represents the pixel value at the zero based position `x` across and `y` down the image with the origin in the top left corner of the image.  
+
+
+        Please note that this is "column-major" order (column changes most rapidly)
+        from the image's row and column perspective, while, from the array's perspective, serialisation is actually effected in "row-major" order (rightmost index changes most rapidly). 
+        This unintuitive outcome arises because the ASCOM Camera Interface specification defines the image column dimension as the rightmost array dimension.
+
+
+        ```
+
+        [
+          [P00,P01,P02,P03,P04],
+
+          [P10,P11,P12,P13,P14],
+          
+          [P20,P21,P22,P23,P24],
+          
+          [P30,P31,P32,P33,P34],
+          
+          [P40,P41,P42,P43,P44],
+          
+          [P50,P51,P52,P53,P54],
+          
+          [P60,P61,P62,P63,P64],
+
+          …
+        ]
+
+        ```
+
+
+        When the `SensorType` is Color, the serialised JSON array will have 3 dimensions. For example, the returned array should appear as below if `NumX = 7`, `NumY = 5` 
+        and `Rxy`, `Gxy` and `Bxy` represent the red, green and blue pixel values at the zero based position x across and y down the image with the origin in the top left corner of the image.  Please see note above regarding element ordering.
+
+
+        ```
+
+        [
+          [[R00,G00,B00],[R01,G01,B01],[R02,G02,B02],[R03,G03,B03],[R04,G04,B04]],
+
+
+          [[R10,G10,B10],[R11,G11,B11],[R12,G12,B12],[R13,G13,B13],[R14,G14,B14]],
+
+
+          [[R20,G20,B20],[R21,G21,B21],[R22,G22,B22],[R23,G23,B23],[R24,G24,B24]],
+
+
+          [[R30,G30,B30],[R31,G31,B31],[R32,G32,B32],[R33,G33,B33],[R34,G34,B34]],
+
+
+          [[R40,G40,B40],[R41,G41,B41],[R42,G42,B42],[R43,G43,B43],[R44,G44,B44]],
+
+
+          [[R50,G50,B50],[R51,G51,B51],[R52,G52,B52],[R53,G53,B53],[R54,G54,B54]],
+
+
+          [[R60,G60,B60],[R61,G61,B61],[R62,G62,B62],[R63,G63,B63],[R64,G64,B64]],
+
+          …
+        ]
+
+        ```
+
+        ## Performance
+
+        Returning an image from an Alpaca device as a JSON array is very inefficient and can result in delays of 30 or more seconds while client and device process and send the huge JSON string over the network. 
+        A new, much faster mechanic called ImageBytes - [Alpaca ImageBytes Concepts and Implementation](https://www.ascom-standards.org/Developer/AlpacaImageBytes.pdf) has been developed that sends data as a binary byte stream and can offer a 10 to 20 fold reduction in transfer time. 
+        It is strongly recommended that Alpaca Cameras implement the ImageBytes mechanic as well as the JSON mechanic.
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/ImageArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/imagearrayvariant':
+    get:
+      deprecated: true
+      summary: Returns an array of numbers containing the exposure pixel values
+      description: >
+        **This method is deprecated in favour of [`imagearray`](#/Camera%20Specific%20Methods/get_camera__device_number__imagearray)
+        but the endpoint must still be implemented in Alpaca devices and must return a NotImplemented error number (0x400).**
+          
+
+        Further information here: [ImageArrayVariant](https://ascom-standards.org/newdocs/camera.html#Camera.ImageArrayVariant)
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/ImageArrayVariantResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/imageready':
+    get:
+      summary: Indicates that an image is ready to be downloaded
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ImageReady](https://ascom-standards.org/newdocs/camera.html#Camera.ImageReady)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/ispulseguiding':
+    get:
+      summary: Indicates that the camera is pulse guideing.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [IsPulseGuiding](https://ascom-standards.org/newdocs/camera.html#Camera.IsPulseGuiding)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/lastexposureduration':
+    get:
+      summary: Duration of the last exposure (seconds)
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [LastExposureDuration](https://ascom-standards.org/newdocs/camera.html#Camera.LastExposureDuration)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/lastexposurestarttime':
+    get:
+      summary: Start time of the last exposure in FITS standard format CCYY-MM-DDThh:mm:ss[.sss...]. The time must be UTC.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [LastExposureStartTime](https://ascom-standards.org/newdocs/camera.html#Camera.LastExposureStartTime)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/LastExposureStartTimeResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/maxadu':
+    get:
+      summary: Camera's maximum ADU value
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxADU](https://ascom-standards.org/newdocs/camera.html#Camera.MaxADU)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/maxbinx':
+    get:
+      summary: Maximum binning for the camera X axis
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxBinX](https://ascom-standards.org/newdocs/camera.html#Camera.MaxBinX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntMinimum1Response'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/maxbiny':
+    get:
+      summary: Maximum binning for the camera Y axis
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxBinY](https://ascom-standards.org/newdocs/camera.html#Camera.MaxBinY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntMinimum1Response'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/numx':
+    get:
+      summary: Returns the current subframe width in binned pixels.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [NumX](https://ascom-standards.org/newdocs/camera.html#Camera.NumX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the current subframe width in binned pixels.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [NumX](https://ascom-standards.org/newdocs/camera.html#Camera.NumX)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    NumX:
+                      description: >-
+                        Sets the subframe width, if binning is active, value is in binned
+                        pixels.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - NumX
+  '/camera/{device_number}/numy':
+    get:
+      summary: Returns the current subframe height in binned pixels.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [NumY](https://ascom-standards.org/newdocs/camera.html#Camera.NumY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the current subframe height in binned pixels.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [NumY](https://ascom-standards.org/newdocs/camera.html#Camera.NumY)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    NumY:
+                      description: >-
+                        Sets the subframe height, if binning is active, value is in binned
+                        pixels.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - NumY
+  '/camera/{device_number}/offset':
+    get:
+      summary: Returns the camera's offset (OFFSET VALUE MODE) OR the index of the selected camera offset description in the offsets array (OFFSETS INDEX MODE).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Offset](https://ascom-standards.org/newdocs/camera.html#Camera.Offset)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the camera's offset (OFFSET VALUE MODE) OR the index of the selected camera offset description in the offsets array (OFFSETS INDEX MODE).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Offset](https://ascom-standards.org/newdocs/camera.html#Camera.Offset)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Offset:
+                      description: Index of the current camera offset in the offsets string array.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - Offset
+  '/camera/{device_number}/offsetmax':
+    get:
+      summary: Maximum offset value of that this camera supports
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [OffsetMax](https://ascom-standards.org/newdocs/camera.html#Camera.OffsetMax)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/offsetmin':
+    get:
+      summary: Minimum offset value of that this camera supports 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [OffsetMin](https://ascom-standards.org/newdocs/camera.html#Camera.OffsetMin)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/offsets':
+    get:
+      summary: List of offset names supported by the camera 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Offsets](https://ascom-standards.org/newdocs/camera.html#Camera.Offsets)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/percentcompleted':
+    get:
+      summary: Indicates percentage completeness of the current operation
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [PercentCompleted](https://ascom-standards.org/newdocs/camera.html#Camera.PercentCompleted)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/PercentIntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/pixelsizex':
+    get:
+      summary: Width of CCD chip pixels (microns)
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [PixelSizeX](https://ascom-standards.org/newdocs/camera.html#Camera.PixelSizeX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/pixelsizey':
+    get:
+      summary: Height of CCD chip pixels (microns)
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [PixelSizeY](https://ascom-standards.org/newdocs/camera.html#Camera.PixelSizeY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/readoutmode':
+    get:
+      summary: Indicates the canera's readout mode as an index into the array ReadoutModes
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ReadoutMode](https://ascom-standards.org/newdocs/camera.html#Camera.ReadoutMode)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Set the camera's readout mode
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ReadoutMode](https://ascom-standards.org/newdocs/camera.html#Camera.ReadoutMode)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    ReadoutMode:
+                      description: >-
+                        Index into the ReadoutModes array of string readout mode names
+                        indicating the camera's current readout mode.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - ReadoutMode
+  '/camera/{device_number}/readoutmodes':
+    get:
+      summary: Returns a string list of available readout modes
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ReadoutModes](https://ascom-standards.org/newdocs/camera.html#Camera.ReadoutModes)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/sensorname':
+    get:
+      summary: Returns the camera's sensor name
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SensorName](https://ascom-standards.org/newdocs/camera.html#Camera.SensorName)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/sensortype':
+    get:
+      summary: Returns a value indicating whether the sensor is monochrome, or what Bayer matrix it encodes.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SensorType](https://ascom-standards.org/newdocs/camera.html#Camera.SensorType)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/SensorTypeResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/camera/{device_number}/setccdtemperature':
+    get:
+      summary: Returns the current camera cooler setpoint in degrees Celsius.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetCCDTemperature](https://ascom-standards.org/newdocs/camera.html#Camera.SetCCDTemperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Set the camera's cooler setpoint (degrees Celsius).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetCCDTemperature](https://ascom-standards.org/newdocs/camera.html#Camera.SetCCDTemperature)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SetCCDTemperature:
+                      description: Temperature set point (degrees Celsius).
+                      type: number
+                      example: -10
+                  required:
+                    - SetCCDTemperature
+  '/camera/{device_number}/startx':
+    get:
+      summary: Returns the current subframe X axis start position in binned pixels
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StartX](https://ascom-standards.org/newdocs/camera.html#Camera.StartX)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the current subframe X axis start position in binned pixels
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StartX](https://ascom-standards.org/newdocs/camera.html#Camera.StartX)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    StartX:
+                      description: The subframe X axis start position in binned pixels.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - StartX
+  '/camera/{device_number}/starty':
+    get:
+      summary: Returns the current subframe Y axis start position in binned pixels
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StartY](https://ascom-standards.org/newdocs/camera.html#Camera.StartY)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the current subframe Y axis start position in bined pixels
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StartY](https://ascom-standards.org/newdocs/camera.html#Camera.StartY)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    StartY:
+                      description: The subframe Y axis start position in binned pixels.
+                      type: integer
+                      format: int32
+                      example: 0
+                  required:
+                    - StartY
+  '/camera/{device_number}/subexposureduration':
+    get:
+      summary: Camera's sub-exposure interval
+      description: >-
+        `ICameraV3 and later` The Camera's sub exposure duration in seconds.
+        
+        
+        "See this link for the canonical definition, which may include further information and implementation requirements: [SubExposureDuration](https://ascom-standards.org/newdocs/camera.html#Camera.SubExposureDuration)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the current Sub Exposure Duration
+      description: >-
+        `ICameraV3 and later` Sets image sub exposure duration in seconds.
+        
+        
+        "See this link for the canonical definition, which may include further information and implementation requirements: [SubExposureDuration](https://ascom-standards.org/newdocs/camera.html#Camera.SubExposureDuration)"
+      tags:
+        - Camera Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SubExposureDuration:
+                      description: The request sub exposure duration in seconds
+                      type: number
+                      example: 0
+                  required:
+                    - SubExposureDuration
+  '/camera/{device_number}/abortexposure':
+    put:
+      summary: Aborts the current exposure and returns the camera to Idle state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AbortExposure](https://ascom-standards.org/newdocs/camera.html#Camera.AbortExposure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/camera/{device_number}/pulseguide':
+    put:
+      summary: Pulse guide in the specified direction for the specified time.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [PulseGuide](https://ascom-standards.org/newdocs/camera.html#Camera.PulseGuide)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Direction:
+                      $ref: '#/components/schemas/GuideDirection'
+                    Duration:
+                      description: Duration of movement in milli-seconds
+                      type: integer
+                      format: int32
+                  required:
+                    - Direction
+                    - Duration
+  '/camera/{device_number}/startexposure':
+    put:
+      summary: Starts an exposure
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StartExposure](https://ascom-standards.org/newdocs/camera.html#Camera.StartExposure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Duration:
+                      description: Duration of exposure in seconds
+                      type: number
+                    Light:
+                      description: 'True if light frame, false if dark frame.'
+                      type: boolean
+                  required:
+                    - Duration
+                    - Light
+  '/camera/{device_number}/stopexposure':
+    put:
+      summary: Stops the current exposure
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StopExposure](https://ascom-standards.org/newdocs/camera.html#Camera.StopExposure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Camera Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+
+
+
+  '/covercalibrator/{device_number}/brightness':
+    get:
+      summary: Returns the current calibrator brightness
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Brightness](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.Brightness)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/calibratorchanging':
+    get:
+      summary: Completion variable for calibrator brightness changes. 
+      description: >-
+         `ICoverCalibratorV2 and later` Further information here: [CalibratorChanging](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CalibratorChanging)
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/calibratorstate':
+    get:
+      summary: Returns the state of the calibration device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CalibratorState](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CalibratorState)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/CalibratorStatusResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/covermoving':
+    get:
+      summary: Completion variable for cover open and close operations.
+      description: >-
+         `ICoverCalibratorV2 and later` Further information here: [CoverMoving](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CoverMoving)
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/coverstate':
+    get:
+      summary: Returns the state of the device cover" 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CoverState](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CoverState)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/CoverStatusResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/maxbrightness':
+    get:
+      summary: Returns the calibrator's maximum Brightness value.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxBrightness](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.MaxBrightness)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/covercalibrator/{device_number}/calibratoroff':
+    put:
+      summary: Turns the calibrator off
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CalibratorOff](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CalibratorOff)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/covercalibrator/{device_number}/calibratoron':
+    put:
+      summary: Turns the calibrator on at the specified brightness
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CalibratorOn](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CalibratorOn)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Brightness:
+                      description: The required brightness in the range 0 to MaxBrightness
+                      type: integer
+                      format: int32
+                  required:
+                    - Brightness
+  '/covercalibrator/{device_number}/closecover':
+    put:
+      summary: Initiates cover closing 
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CloseCover](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.CloseCover)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/covercalibrator/{device_number}/haltcover':
+    put:
+      summary: Stops any cover movement that may be in progress
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [HaltCover](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.HaltCover)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/covercalibrator/{device_number}/opencover':
+    put:
+      summary: Initiates cover opening.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [OpenCover](https://ascom-standards.org/newdocs/covercalibrator.html#CoverCalibrator.OpenCover)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - CoverCalibrator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+
+
+  '/dome/{device_number}/altitude':
+    get:
+      summary: The dome altitude (degrees - horizon zero, increasing positive to 90 zenith).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Altitude](https://ascom-standards.org/newdocs/dome.html#Dome.Altitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/athome':
+    get:
+      summary: Indicates whether the dome is in the home position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AtHome](https://ascom-standards.org/newdocs/dome.html#Dome.AtHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/atpark':
+    get:
+      summary: Indicates whether the dome is at the park position
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AtPark](https://ascom-standards.org/newdocs/dome.html#Dome.AtPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/azimuth':
+    get:
+      summary: "The dome azimuth (degrees - North zero, increasing clockwise: 90 East, 180 South, 270 West)"
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Azimuth](https://ascom-standards.org/newdocs/dome.html#Dome.Azimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/canfindhome':
+    get:
+      summary: Indicates whether the dome can find the home position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanFindHome](https://ascom-standards.org/newdocs/dome.html#Dome.CanFindHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/canpark':
+    get:
+      summary: Indicates whether the dome can be parked.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanPark](https://ascom-standards.org/newdocs/dome.html#Dome.CanPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/cansetaltitude':
+    get:
+      summary: Indicates whether the dome altitude can be set
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetAltitude](https://ascom-standards.org/newdocs/dome.html#Dome.CanSetAltitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/cansetazimuth':
+    get:
+      summary: Indicates whether the dome azimuth can be set
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetAzimuth](https://ascom-standards.org/newdocs/dome.html#Dome.CanSetAzimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/cansetpark':
+    get:
+      summary: Indicates whether the dome park position can be set
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetPark](https://ascom-standards.org/newdocs/dome.html#Dome.CanSetPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/cansetshutter':
+    get:
+      summary: Indicates whether the dome shutter can be opened
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetShutter](https://ascom-standards.org/newdocs/dome.html#Dome.CanSetShutter)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/canslave':
+    get:
+      summary: Indicates whether the dome supports slaving to a telescope
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSlave](https://ascom-standards.org/newdocs/dome.html#Dome.CanSlave)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/cansyncazimuth':
+    get:
+      summary: Indicates whether the dome azimuth position can be synched
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSyncAzimuth](https://ascom-standards.org/newdocs/dome.html#Dome.CanSyncAzimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/shutterstatus':
+    get:
+      summary: Status of the dome shutter or roll-off roof
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ShutterStatus](https://ascom-standards.org/newdocs/dome.html#Dome.ShutterStatus)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/ShutterStateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/slaved':
+    get:
+      summary: Indicates whether the dome is slaved to the telescope
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Slaved](https://ascom-standards.org/newdocs/dome.html#Dome.Slaved)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets whether the dome is slaved to the telescope
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Slaved](https://ascom-standards.org/newdocs/dome.html#Dome.Slaved)"
+      tags:
+        - Dome Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Slaved:
+                      description: 'True if telescope is slaved to dome, otherwise false'
+                      type: boolean
+                      example: false
+                  required:
+                    - Slaved
+  '/dome/{device_number}/slewing':
+    get:
+      summary: Indicates whether the any part of the dome is moving
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Slewing](https://ascom-standards.org/newdocs/dome.html#Dome.Slewing)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/dome/{device_number}/abortslew':
+    put:
+      summary: Immediately cancel current dome operation.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AbortSlew](https://ascom-standards.org/newdocs/dome.html#Dome.AbortSlew)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/closeshutter':
+    put:
+      summary: Close the shutter or otherwise shield telescope from the sky.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CloseShutter](https://ascom-standards.org/newdocs/dome.html#Dome.CloseShutter)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/findhome':
+    put:
+      summary: Start operation to search for the dome home position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FindHome](https://ascom-standards.org/newdocs/dome.html#Dome.FindHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/openshutter':
+    put:
+      summary: Open shutter or otherwise expose telescope to the sky.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [OpenShutter](https://ascom-standards.org/newdocs/dome.html#Dome.OpenShutter)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/park':
+    put:
+      summary: Rotate dome in azimuth to park position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Park](https://ascom-standards.org/newdocs/dome.html#Dome.Park)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/setpark':
+    put:
+      summary: >-
+        Set the current azimuth, altitude position of dome to be the park
+        position
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetPark](https://ascom-standards.org/newdocs/dome.html#Dome.SetPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/dome/{device_number}/slewtoaltitude':
+    put:
+      summary: Slew the dome to the given altitude position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToAltitude](https://ascom-standards.org/newdocs/dome.html#Dome.SlewToAltitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Altitude:
+                      description: >-
+                        Target dome altitude (degrees, horizon zero and increasing positive to 90
+                        zenith)
+                      type: number
+                  required:
+                    - Altitude
+  '/dome/{device_number}/slewtoazimuth':
+    put:
+      summary: Slew the dome to the given azimuth position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToAzimuth](https://ascom-standards.org/newdocs/dome.html#Dome.SlewToAzimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putDome_devicenumber_slewtoazimuth'
+  '/dome/{device_number}/synctoazimuth':
+    put:
+      summary: Synchronize the current position of the dome to the given azimuth.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SyncToAzimuth](https://ascom-standards.org/newdocs/dome.html#Dome.SyncToAzimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Dome Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putDome_devicenumber_slewtoazimuth'
+
+  '/filterwheel/{device_number}/focusoffsets':
+    get:
+      summary: Returns an integer array of filter focus offsets
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FocusOffsets](https://ascom-standards.org/newdocs/filterwheel.html#FilterWheel.FocusOffsets)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - FilterWheel Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/filterwheel/{device_number}/names':
+    get:
+      summary: Filter wheel filter names
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Names](https://ascom-standards.org/newdocs/filterwheel.html#FilterWheel.Names)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - FilterWheel Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringArrayResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/filterwheel/{device_number}/position':
+    get:
+      summary: Returns the current filter wheel position
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Position](https://ascom-standards.org/newdocs/filterwheel.html#FilterWheel.Position)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - FilterWheel Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the filter wheel position
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Position](https://ascom-standards.org/newdocs/filterwheel.html#FilterWheel.Position)"
+      tags:
+        - FilterWheel Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: The number of the filter wheel position to select
+                      type: integer
+                      format: int32
+                  required:
+                    - Position
+
+  '/focuser/{device_number}/absolute':
+    get:
+      summary: Indicates whether the focuser is capable of absolute position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Absolute](https://ascom-standards.org/newdocs/focuser.html#Focuser.Absolute)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/ismoving':
+    get:
+      summary: Indicates whether the focuser is currently moving.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [IsMoving](https://ascom-standards.org/newdocs/focuser.html#Focuser.IsMoving)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/maxincrement':
+    get:
+      summary: Returns the focuser's maximum increment size.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxIncrement](https://ascom-standards.org/newdocs/focuser.html#Focuser.MaxIncrement)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/maxstep':
+    get:
+      summary: Returns the focuser's maximum step size.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxStep](https://ascom-standards.org/newdocs/focuser.html#Focuser.MaxStep)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/position':
+    get:
+      summary: Returns the focuser's current position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Position](https://ascom-standards.org/newdocs/focuser.html#Focuser.Position)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/stepsize':
+    get:
+      summary: Returns the focuser's step size.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StepSize](https://ascom-standards.org/newdocs/focuser.html#Focuser.StepSize)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/tempcomp':
+    get:
+      summary: Retrieves the state of temperature compensation mode
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TempComp](https://ascom-standards.org/newdocs/focuser.html#Focuser.TempComp)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the device's temperature compensation mode.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TempComp](https://ascom-standards.org/newdocs/focuser.html#Focuser.TempComp)"
+      tags:
+        - Focuser Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    TempComp:
+                      description: >-
+                        Set true to enable the focuser's temperature compensation mode, otherwise
+                        false for normal operation.
+                      type: boolean
+                  required:
+                    - TempComp
+  '/focuser/{device_number}/tempcompavailable':
+    get:
+      summary: Indicates whether the focuser has temperature compensation.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TempCompAvailable](https://ascom-standards.org/newdocs/focuser.html#Focuser.TempCompAvailable)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/temperature':
+    get:
+      summary: Returns the focuser's current temperature.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Temperature](https://ascom-standards.org/newdocs/focuser.html#Focuser.Temperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/focuser/{device_number}/halt':
+    put:
+      summary: Immediatley stops focuser motion.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Halt](https://ascom-standards.org/newdocs/focuser.html#Focuser.Halt)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/focuser/{device_number}/move':
+    put:
+      summary: Moves the focuser to a new position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Move](https://ascom-standards.org/newdocs/focuser.html#Focuser.Move)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Focuser Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: >-
+                        Step distance or absolute position, depending on the value of the Absolute
+                        property
+                      type: integer
+                      format: int32
+                  required:
+                    - Position
+
+  '/observingconditions/{device_number}/averageperiod':
+    get:
+      summary: Returns the time period over which observations will be averaged
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AveragePeriod](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.AveragePeriod)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the time period over which observations will be averaged
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AveragePeriod](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.AveragePeriod)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    AveragePeriod:
+                      description: Time period (hours) over which to average sensor readings
+                      type: number
+                      example: 0.15
+                  required:
+                    - AveragePeriod
+  '/observingconditions/{device_number}/cloudcover':
+    get:
+      summary: Returns the amount of sky obscured by cloud
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CloudCover](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.CloudCover)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/PercentDoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/dewpoint':
+    get:
+      summary: Returns the atmospheric dew point at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DewPoint](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.DewPoint)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/humidity':
+    get:
+      summary: Returns the atmospheric humidity at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Humidity](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.Humidity)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/pressure':
+    get:
+      summary: Returns the atmospheric pressure at the observatory.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Pressure](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.Pressure)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/rainrate':
+    get:
+      summary: Returns the rain rate at the observatory.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [RainRate](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.RainRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/skybrightness':
+    get:
+      summary: Returns the sky brightness at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SkyBrightness](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.SkyBrightness)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/skyquality':
+    get:
+      summary: Returns the sky quality at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SkyQuality](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.SkyQuality)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/skytemperature':
+    get:
+      summary: Returns the sky temperature at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SkyTemperature](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.SkyTemperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/starfwhm':
+    get:
+      summary: Returns the seeing at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StarFWHM](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.StarFWHM)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/temperature':
+    get:
+      summary: Returns the temperature at the observatory (°C)
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Temperature](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.Temperature)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/winddirection':
+    get:
+      summary: Returns the wind direction at the observatory
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [WindDirection](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.WindDirection)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/windgust':
+    get:
+      summary: >-
+        Returns the peak 3 second wind gust at the observatory over the last 2
+        minutes
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [WindGust](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.WindGust)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/windspeed':
+    get:
+      summary: Returns the wind speed at the observatory.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [WindSpeed](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.WindSpeed)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/refresh':
+    put:
+      summary: Refreshes sensor values from hardware.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Refresh](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.Refresh)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/observingconditions/{device_number}/sensordescription':
+    get:
+      summary: Return a sensor description
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SensorDescription](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.SensorDescription)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - name: SensorName
+          description: Name of the sensor whose description is required
+          in: query
+          required: true
+          schema:
+            type: string
+            example: Pressure
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/observingconditions/{device_number}/timesincelastupdate':
+    get:
+      summary: Return the time since the sensor value was last updated
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TimeSinceLastUpdate](https://ascom-standards.org/newdocs/observingconditions.html#ObservingConditions.TimeSinceLastUpdate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - name: SensorName
+          description: Name of the sensor whose last update time is required
+          in: query
+          required: true
+          schema:
+            type: string
+            example: Pressure
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - ObservingConditions Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+
+  '/rotator/{device_number}/canreverse':
+    get:
+      summary: True if the Rotator supports the Reverse method.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanReverse](https://ascom-standards.org/newdocs/rotator.html#Rotator.CanReverse)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/ismoving':
+    get:
+      summary: Returns True if the rotator is currently moving to a new position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [IsMoving](https://ascom-standards.org/newdocs/rotator.html#Rotator.IsMoving)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/mechanicalposition':
+    get:
+      summary: Returns the rotator's mechanical current position (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MechanicalPosition](https://ascom-standards.org/newdocs/rotator.html#Rotator.MechanicalPosition)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/position':
+    get:
+      summary: Returns the rotator's current position (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Position](https://ascom-standards.org/newdocs/rotator.html#Rotator.Position)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/reverse':
+    get:
+      summary: Returns the rotator’s Reverse state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Reverse](https://ascom-standards.org/newdocs/rotator.html#Rotator.Reverse)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the rotator’s Reverse state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Reverse](https://ascom-standards.org/newdocs/rotator.html#Rotator.Reverse)"
+      tags:
+        - Rotator Specific Methods
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Reverse:
+                      description: >-
+                        True if the rotation and angular direction must be reversed to match the
+                        optical characteristcs
+                      type: boolean
+                  required:
+                    - Reverse
+  '/rotator/{device_number}/stepsize':
+    get:
+      summary: Returns the minimum StepSize (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [StepSize](https://ascom-standards.org/newdocs/rotator.html#Rotator.StepSize)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/targetposition':
+    get:
+      summary: Returns the destination position angle (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TargetPosition](https://ascom-standards.org/newdocs/rotator.html#Rotator.TargetPosition)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/rotator/{device_number}/halt':
+    put:
+      summary: Immediatley stops rotator motion.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Halt](https://ascom-standards.org/newdocs/rotator.html#Rotator.Halt)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/rotator/{device_number}/move':
+    put:
+      summary: Moves the rotator to a new position relative to the current position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Move](https://ascom-standards.org/newdocs/rotator.html#Rotator.Move)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: Relative position to move in degrees from current Position.
+                      type: number
+                      format: double
+                  required:
+                    - Position
+  '/rotator/{device_number}/moveabsolute':
+    put:
+      summary: Moves the rotator to a new absolute position (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MoveAbsolute](https://ascom-standards.org/newdocs/rotator.html#Rotator.MoveAbsolute)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: Absolute position in degrees.
+                      type: number
+                      format: double
+                  required:
+                    - Position
+  '/rotator/{device_number}/movemechanical':
+    put:
+      summary: Moves the rotator to a new raw mechanical position (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MoveMechanical](https://ascom-standards.org/newdocs/rotator.html#Rotator.MoveMechanical)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: Absolute position in degrees.
+                      type: number
+                      format: double
+                  required:
+                    - Position
+  '/rotator/{device_number}/sync':
+    put:
+      summary: Syncs the rotator to the specified position angle without moving it.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Sync](https://ascom-standards.org/newdocs/rotator.html#Rotator.Sync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Rotator Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Position:
+                      description: Absolute position in degrees.
+                      type: number
+                      format: double
+                  required:
+                    - Position
+
+  '/safetymonitor/{device_number}/issafe':
+    get:
+      summary: Indicates whether the monitored state is safe for use.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [IsSafe](https://ascom-standards.org/newdocs/safetymonitor.html#SafetyMonitor.IsSafe)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - SafetyMonitor Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+
+  '/switch/{device_number}/maxswitch':
+    get:
+      summary: The number of switch devices managed by this driver
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxSwitch](https://ascom-standards.org/newdocs/switch.html#Switch.MaxSwitch)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/canasync':
+    get:
+      summary: Returns a Flag indicating whether the specified switch can operate asynchronously. 
+      description: "`ISwitchV3 and later` See this link for the canonical definition, which may include further information and implementation requirements: [CanAsync](https://ascom-standards.org/newdocs/switch.html#Switch.CanAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/canwrite':
+    get:
+      summary: Indicates whether the specified switch device can be written to
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanWrite](https://ascom-standards.org/newdocs/switch.html#Switch.CanWrite)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/getswitch':
+    get:
+      summary: Return the state of the specified switch device as a boolean
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GetSwitch](https://ascom-standards.org/newdocs/switch.html#Switch.GetSwitch)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/getswitchdescription':
+    get:
+      summary: Returns the description of the specified switch device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GetSwitchDescription](https://ascom-standards.org/newdocs/switch.html#Switch.GetSwitchDescription)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/getswitchname':
+    get:
+      summary: Returns the name of the specified switch device
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GetSwitchName](https://ascom-standards.org/newdocs/switch.html#Switch.GetSwitchName)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/StringResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/getswitchvalue':
+    get:
+      summary: Returns the value of the specified switch device as a double
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GetSwitchValue](https://ascom-standards.org/newdocs/switch.html#Switch.GetSwitchValue)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/minswitchvalue':
+    get:
+      summary: Returns the minimum value of the specified switch device as a double
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MinSwitchValue](https://ascom-standards.org/newdocs/switch.html#Switch.MinSwitchValue)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/maxswitchvalue':
+    get:
+      summary: Gets the maximum value of the specified switch device as a double
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MaxSwitchValue](https://ascom-standards.org/newdocs/switch.html#Switch.MaxSwitchValue)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/setasync':
+    put:
+      summary: Sets a switch's boolean state asynchronously
+      description: "`ISwitchV3 and later` See this link for the canonical definition, which may include further information and implementation requirements: [SetAsync](https://ascom-standards.org/newdocs/switch.html#Switch.SetAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Id:
+                      description: The device number (0 to MaxSwitch - 1)
+                      type: integer
+                      format: int32
+                    State:
+                      description: The required control state (True or False)
+                      type: boolean
+                  required:
+                    - Id
+                    - State
+  '/switch/{device_number}/setasyncvalue':
+    put:
+      summary: Set a switch's double value asynchronously
+      description: "`ISwitchV3 and later` See this link for the canonical definition, which may include further information and implementation requirements: [SetAsyncValue](https://ascom-standards.org/newdocs/switch.html#Switch.SetAsyncValue)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Id:
+                      description: The device number (0 to MaxSwitch - 1)
+                      type: integer
+                      format: int32
+                    Value:
+                      description: 'The value to be set, between MinSwitchValue and MaxSwitchValue'
+                      type: number
+                  required:
+                    - Id
+                    - Value  
+  '/switch/{device_number}/setswitch':
+    put:
+      summary: Sets a switch device to the specified boolean state
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetSwitch](https://ascom-standards.org/newdocs/switch.html#Switch.SetSwitch)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Id:
+                      description: The device number (0 to MaxSwitch - 1)
+                      type: integer
+                      format: int32
+                    State:
+                      description: The required control state (True or False)
+                      type: boolean
+                  required:
+                    - Id
+                    - State
+  '/switch/{device_number}/setswitchname':
+    put:
+      summary: Sets a switch device name to the specified value
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetSwitchName](https://ascom-standards.org/newdocs/switch.html#Switch.SetSwitchName)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Id:
+                      description: The device number (0 to MaxSwitch - 1)
+                      type: integer
+                      format: int32
+                    Name:
+                      description: The name of the device
+                      type: string
+                  required:
+                    - Id
+                    - Name
+  '/switch/{device_number}/setswitchvalue':
+    put:
+      summary: Sets a switch device to the specified double value
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetSwitchValue](https://ascom-standards.org/newdocs/switch.html#Switch.SetSwitchValue)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Id:
+                      description: The device number (0 to MaxSwitch - 1)
+                      type: integer
+                      format: int32
+                    Value:
+                      description: 'The value to be set, between MinSwitchValue and MaxSwitchValue'
+                      type: number
+                  required:
+                    - Id
+                    - Value
+  '/switch/{device_number}/statechangecomplete':
+    get:
+      summary: Completion variable for asynchronous switch state change operations.
+      description: "`ISwitchV3 and later` See this link for the canonical definition, which may include further information and implementation requirements: [StateChangeComplete](https://ascom-standards.org/newdocs/switch.html#Switch.StateChangeComplete)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/switch/{device_number}/switchstep':
+    get:
+      summary: Returns the step size that this device supports.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SwitchStep](https://ascom-standards.org/newdocs/switch.html#Switch.SwitchStep)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/SwitchNumberQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Switch Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+
+  '/telescope/{device_number}/alignmentmode':
+    get:
+      summary: Returns the current mount alignment mode
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AlignmentMode](https://ascom-standards.org/newdocs/telescope.html#Telescope.AlignmentMode)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/AlignmentModeResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/altitude':
+    get:
+      summary: Returns the mount's altitude above the horizon (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Altitude](https://ascom-standards.org/newdocs/telescope.html#Telescope.Altitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/aperturearea':
+    get:
+      summary: Returns the telescope's aperture (square meters).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ApertureArea](https://ascom-standards.org/newdocs/telescope.html#Telescope.ApertureArea)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/aperturediameter':
+    get:
+      summary: Returns the telescope's effective aperture (meters).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [ApertureDiameter](https://ascom-standards.org/newdocs/telescope.html#Telescope.ApertureDiameter)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/athome':
+    get:
+      summary: Indicates whether the mount is at the home position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AtHome](https://ascom-standards.org/newdocs/telescope.html#Telescope.AtHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/atpark':
+    get:
+      summary: Indicates whether the telescope is at the park position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AtPark](https://ascom-standards.org/newdocs/telescope.html#Telescope.AtPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/azimuth':
+    get:
+      summary: Returns the mount's azimuth (degrees, North-referenced, positive East/clockwise).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Azimuth](https://ascom-standards.org/newdocs/telescope.html#Telescope.Azimuth)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canfindhome':
+    get:
+      summary: Indicates whether the mount can find the home position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanFindHome](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanFindHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canpark':
+    get:
+      summary: Indicates whether the telescope can be parked.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanPark](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canpulseguide':
+    get:
+      summary: Indicates whether the telescope can be pulse guided.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanPulseGuide](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanPulseGuide)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansetdeclinationrate':
+    get:
+      summary: Indicates whether the DeclinationRate property can be changed.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetDeclinationRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetDeclinationRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansetguiderates':
+    get:
+      summary: Indicates whether the GuideRate property can be changed.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetGuideRates](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetGuideRates)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansetpark':
+    get:
+      summary: Indicates whether the telescope park position can be set.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetPark](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansetpierside':
+    get:
+      summary: Indicates whether the telescope SideOfPier can be set.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetPierSide](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetPierSide)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansetrightascensionrate':
+    get:
+      summary: Indicates whether the RightAscensionRate can be changed.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetRightAscensionRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetRightAscensionRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansettracking':
+    get:
+      summary: Indicates whether the Tracking state can be changed.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSetTracking](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSetTracking)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canslew':
+    get:
+      summary: Indicates whether the telescope can slew synchronously.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSlew](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSlew)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canslewaltaz':
+    get:
+      summary: Indicates whether the telescope can slew synchronously to AltAz coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSlewAltAz](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSlewAltAz)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canslewaltazasync':
+    get:
+      summary: Indicates whether the telescope can slew asynchronously to AltAz coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSlewAltAzAsync](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSlewAltAzAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canslewasync':
+    get:
+      summary: Indicates whether the telescope can slew asynchronously to equatorial coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSlewAsync](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSlewAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansync':
+    get:
+      summary: Indicates whether the telescope can sync to equatorial coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSync](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/cansyncaltaz':
+    get:
+      summary: Indicates whether the telescope can sync to Alt/Az coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanSyncAltAz](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanSyncAltAz)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canunpark':
+    get:
+      summary: Indicates whether the telescope can be unparked.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanUnpark](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanUnpark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/declination':
+    get:
+      summary: Returns the mount's declination (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Declination](https://ascom-standards.org/newdocs/telescope.html#Telescope.Declination)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/declinationrate':
+    get:
+      summary: Returns the telescope's declination tracking rate (arcseconds per SI second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DeclinationRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.DeclinationRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the telescope's declination tracking rate (arcseconds per SI second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DeclinationRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.DeclinationRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    DeclinationRate:
+                      description: Declination tracking rate (arcseconds per SI second). Please note that rightascensionrate units are arcseconds per sidereal second.
+                      type: number
+                      format: double
+                  required:
+                    - DeclinationRate
+  '/telescope/{device_number}/doesrefraction':
+    get:
+      summary: Indicates whether atmospheric refraction correction is applied to coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DoesRefraction](https://ascom-standards.org/newdocs/telescope.html#Telescope.DoesRefraction)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Determines whether atmospheric refraction correction is applied to coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DoesRefraction](https://ascom-standards.org/newdocs/telescope.html#Telescope.DoesRefraction)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    DoesRefraction:
+                      description: Set True to make the telescope or driver apply atmospheric refraction correction to coordinates.
+                      type: boolean
+                  required:
+                    - DoesRefraction
+  '/telescope/{device_number}/equatorialsystem':
+    get:
+      summary: Returns the current equatorial coordinate system used by this telescope.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [EquatorialSystem](https://ascom-standards.org/newdocs/telescope.html#Telescope.EquatorialSystem)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/EquatorialCoordinateTypeResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/focallength':
+    get:
+      summary: Returns the telescope's focal length (meters).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FocalLength](https://ascom-standards.org/newdocs/telescope.html#Telescope.FocalLength)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/guideratedeclination':
+    get:
+      summary: Returns the  current Declination rate offset for telescope guiding (degrees/sec).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GuideRateDeclination](https://ascom-standards.org/newdocs/telescope.html#Telescope.GuideRateDeclination)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the  current Declination rate offset for telescope guiding (degrees/sec).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GuideRateDeclination](https://ascom-standards.org/newdocs/telescope.html#Telescope.GuideRateDeclination)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    GuideRateDeclination:
+                      description: Declination movement rate offset degrees/sec).
+                      type: number
+                      format: double
+                  required:
+                    - GuideRateDeclination
+  '/telescope/{device_number}/guideraterightascension':
+    get:
+      summary: Returns the  current RightAscension rate offset for telescope guiding (degrees/sec).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GuideRateRightAscension](https://ascom-standards.org/newdocs/telescope.html#Telescope.GuideRateRightAscension)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the  current RightAscension rate offset for telescope guiding (degrees/sec).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [GuideRateRightAscension](https://ascom-standards.org/newdocs/telescope.html#Telescope.GuideRateRightAscension)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    GuideRateRightAscension:
+                      description: RightAscension movement rate offset degrees/sec).
+                      type: number
+                      format: double
+                  required:
+                    - GuideRateRightAscension
+  '/telescope/{device_number}/ispulseguiding':
+    get:
+      summary: Indicates whether the telescope is currently executing a PulseGuide command
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [IsPulseGuiding](https://ascom-standards.org/newdocs/telescope.html#Telescope.IsPulseGuiding)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/rightascension':
+    get:
+      summary: Returns the mount's right ascension coordinate (hours).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [RightAscension](https://ascom-standards.org/newdocs/telescope.html#Telescope.RightAscension)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/RightAscensionResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/rightascensionrate':
+    get:
+      summary: Returns the telescope's right ascension tracking rate (arcseconds per sidereal second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [RightAscensionRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.RightAscensionRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the telescope's right ascension tracking rate (arcseconds per sidereal second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [RightAscensionRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.RightAscensionRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    RightAscensionRate:
+                      description: Right ascension tracking rate (arcseconds per sideral second). Please note that the declinationrate units are arcseconds per SI second.
+                      type: number
+                      format: double
+                  required:
+                    - RightAscensionRate
+  '/telescope/{device_number}/sideofpier':
+    get:
+      summary: Returns the mount's pointing state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SideOfPier](https://ascom-standards.org/newdocs/telescope.html#Telescope.SideOfPier)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/PierSideResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the mount's pointing state.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SideOfPier](https://ascom-standards.org/newdocs/telescope.html#Telescope.SideOfPier)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SideOfPier:
+                      $ref: '#/components/schemas/PierSide'
+                  required:
+                    - SideOfPier
+  '/telescope/{device_number}/siderealtime':
+    get:
+      summary: Returns the local apparent sidereal time.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiderealTime](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiderealTime)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/siteelevation':
+    get:
+      summary: Returns the observing site's elevation above mean sea level (metres).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteElevation](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteElevation)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the observing site's elevation above mean sea level (metres).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteElevation](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteElevation)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SiteElevation:
+                      description: Elevation above mean sea level (metres).
+                      type: number
+                      format: double
+                  required:
+                    - SiteElevation
+  '/telescope/{device_number}/sitelatitude':
+    get:
+      summary: Returns the observing site's latitude (degrees).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteLatitude](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteLatitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the observing site's latitude.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteLatitude](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteLatitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SiteLatitude:
+                      description: Site latitude (degrees)
+                      type: number
+                      format: double
+                  required:
+                    - SiteLatitude
+  '/telescope/{device_number}/sitelongitude':
+    get:
+      summary: Returns the observing site's longitude (degrees, positive East, WGS84).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteLongitude](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteLongitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the observing site's longitude.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SiteLongitude](https://ascom-standards.org/newdocs/telescope.html#Telescope.SiteLongitude)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SiteLongitude:
+                      description: 'Site longitude (degrees, positive East, WGS84)'
+                      type: number
+                      format: double
+                  required:
+                    - SiteLongitude
+  '/telescope/{device_number}/slewing':
+    get:
+      summary: Indicates whether the telescope is currently slewing.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Slewing](https://ascom-standards.org/newdocs/telescope.html#Telescope.Slewing)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/slewsettletime':
+    get:
+      summary: Returns the post-slew settling time.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewSettleTime](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewSettleTime)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/IntResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the post-slew settling time (seconds).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewSettleTime](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewSettleTime)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    SlewSettleTime:
+                      description: Settling time (integer sec.).
+                      type: integer
+                      format: int32
+                  required:
+                    - SlewSettleTime
+  '/telescope/{device_number}/targetdeclination':
+    get:
+      summary: Returns the current target declination (degrees, positive North).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TargetDeclination](https://ascom-standards.org/newdocs/telescope.html#Telescope.TargetDeclination)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DeclinationResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the target declination of a slew or sync (degrees, positive North)
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TargetDeclination](https://ascom-standards.org/newdocs/telescope.html#Telescope.TargetDeclination)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    TargetDeclination:
+                      description: Target declination(degrees)
+                      type: number
+                      format: double
+                  required:
+                    - TargetDeclination
+  '/telescope/{device_number}/targetrightascension':
+    get:
+      summary: Returns the current target right ascension (hours).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TargetRightAscension](https://ascom-standards.org/newdocs/telescope.html#Telescope.TargetRightAscension)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DoubleResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the target right ascension of a slew or sync (hours).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TargetRightAscension](https://ascom-standards.org/newdocs/telescope.html#Telescope.TargetRightAscension)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    TargetRightAscension:
+                      description: Target right ascension(hours)
+                      type: number
+                      format: double
+                  required:
+                    - TargetRightAscension
+  '/telescope/{device_number}/tracking':
+    get:
+      summary: Indicates whether the telescope is tracking.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Tracking](https://ascom-standards.org/newdocs/telescope.html#Telescope.Tracking)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Enables or disables telescope tracking.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Tracking](https://ascom-standards.org/newdocs/telescope.html#Telescope.Tracking)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Tracking:
+                      description: Tracking enabled / disabled
+                      type: boolean
+                  required:
+                    - Tracking
+  '/telescope/{device_number}/trackingrate':
+    get:
+      summary: Returns the current tracking rate.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TrackingRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.TrackingRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DriveRateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the mount's tracking rate.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TrackingRate](https://ascom-standards.org/newdocs/telescope.html#Telescope.TrackingRate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    TrackingRate:
+                      $ref: '#/components/schemas/DriveRate'
+                  required:
+                    - TrackingRate
+  '/telescope/{device_number}/trackingrates':
+    get:
+      summary: Returns a collection of supported DriveRates values.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [TrackingRates](https://ascom-standards.org/newdocs/telescope.html#Telescope.TrackingRates)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/DriveRatesResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/utcdate':
+    get:
+      summary: Returns the UTC date/time of the telescope's internal clock as a string.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [UTCDate](https://ascom-standards.org/newdocs/telescope.html#Telescope.UTCDate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/TelescopeUTCDateResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+    put:
+      summary: Sets the UTC date/time of the telescope's internal clock.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [UTCDate](https://ascom-standards.org/newdocs/telescope.html#Telescope.UTCDate)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    UTCDate:
+                      $ref: '#/components/schemas/TelescopeUTCDate'
+                  required:
+                    - UTCDate
+  '/telescope/{device_number}/abortslew':
+    put:
+      summary: Immediatley stops a slew in progress.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AbortSlew](https://ascom-standards.org/newdocs/telescope.html#Telescope.AbortSlew)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/axisrates':
+    get:
+      summary: Returns the rates at which the telescope may be moved about the specified axis (degrees / second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [AxisRates](https://ascom-standards.org/newdocs/telescope.html#Telescope.AxisRates)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+        - $ref: '#/components/parameters/AxisQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/AxisRatesResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/canmoveaxis':
+    get:
+      summary: Indicates whether the telescope can move the requested axis.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [CanMoveAxis](https://ascom-standards.org/newdocs/telescope.html#Telescope.CanMoveAxis)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/AxisQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/BoolResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/destinationsideofpier':
+    get:
+      summary: Predicts the pointing state after a German equatorial mount slews to given coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [DestinationSideOfPier](https://ascom-standards.org/newdocs/telescope.html#Telescope.DestinationSideOfPier)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+        - $ref: '#/components/parameters/RightAscensionQuery'
+        - $ref: '#/components/parameters/DeclinationQuery'
+        - $ref: '#/components/parameters/ClientIDQuery'
+        - $ref: '#/components/parameters/ClientTransactionIDQuery'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/PierSideResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+  '/telescope/{device_number}/findhome':
+    put:
+      summary: Moves the mount to its "home" position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [FindHome](https://ascom-standards.org/newdocs/telescope.html#Telescope.FindHome)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/moveaxis':
+    put:
+      summary: Moves a telescope axis at the given rate (degrees / second).
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [MoveAxis](https://ascom-standards.org/newdocs/telescope.html#Telescope.MoveAxis)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Axis:
+                      $ref: '#/components/schemas/TelescopeAxis'
+                    Rate:
+                      description: The rate of motion (deg/sec) about the specified axis
+                      type: number
+                      example: 0
+                  required:
+                    - Axis
+                    - Rate
+  '/telescope/{device_number}/park':
+    put:
+      summary: Parks the mount
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Park](https://ascom-standards.org/newdocs/telescope.html#Telescope.Park)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/pulseguide':
+    put:
+      summary: Moves the scope in the given direction for the given time.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [PulseGuide](https://ascom-standards.org/newdocs/telescope.html#Telescope.PulseGuide)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/AlpacaRequest'
+                - properties:
+                    Direction:
+                      $ref: '#/components/schemas/GuideDirection'
+                    Duration:
+                      description: The duration of the guide-rate motion (milliseconds)
+                      type: integer
+                      format: int32
+                      example: 5
+                  required:
+                    - Direction
+                    - Duration
+  '/telescope/{device_number}/setpark':
+    put:
+      summary: Sets the current position as the telescope's park position.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SetPark](https://ascom-standards.org/newdocs/telescope.html#Telescope.SetPark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/slewtoaltaz':
+    put:
+      deprecated: true
+      summary: Synchronously slew to the given Alt/Az coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToAltAz](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToAltAz)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtoaltaz'
+  '/telescope/{device_number}/slewtoaltazasync':
+    put:
+      summary: Asynchronously slew to the given Alt/Az coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToAltAzAsync](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToAltAzAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtoaltaz'
+  '/telescope/{device_number}/slewtocoordinates':
+    put:
+      deprecated: true
+      summary: Synchronously slew to the given equatorial coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToCoordinates](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToCoordinates)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtocoordinates'
+  '/telescope/{device_number}/slewtocoordinatesasync':
+    put:
+      summary: Asynchronously slew to the given equatorial coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToCoordinatesAsync](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToCoordinatesAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtocoordinates'
+  '/telescope/{device_number}/slewtotarget':
+    put:
+      deprecated: true
+      summary: Synchronously slew to the TargetRightAscension and TargetDeclination coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToTarget](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToTarget)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/slewtotargetasync':
+    put:
+      summary: Asynchronously slew to the TargetRightAscension and TargetDeclination coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SlewToTargetAsync](https://ascom-standards.org/newdocs/telescope.html#Telescope.SlewToTargetAsync)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/synctoaltaz':
+    put:
+      summary: Sync to the given Alt/Az coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SyncToAltAz](https://ascom-standards.org/newdocs/telescope.html#Telescope.SyncToAltAz)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtoaltaz'
+  '/telescope/{device_number}/synctocoordinates':
+    put:
+      summary: Syncs to the given equatorial coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SyncToCoordinates](https://ascom-standards.org/newdocs/telescope.html#Telescope.SyncToCoordinates)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putTelescope_devicenumber_slewtocoordinates'
+  '/telescope/{device_number}/synctotarget':
+    put:
+      summary: Syncs to the TargetRightAscension and TargetDeclination coordinates.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [SyncToTarget](https://ascom-standards.org/newdocs/telescope.html#Telescope.SyncToTarget)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+  '/telescope/{device_number}/unpark':
+    put:
+      summary: Unparks the mount.
+      description: "See this link for the canonical definition, which may include further information and implementation requirements: [Unpark](https://ascom-standards.org/newdocs/telescope.html#Telescope.Unpark)"
+      parameters:
+        - $ref: '#/components/parameters/device_number'
+      tags:
+        - Telescope Specific Methods
+      responses:
+        '200':
+          $ref: '#/components/responses/MethodResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+      requestBody:
+        $ref: '#/components/requestBodies/putStandardClientParameters'
+
+
+
+components:
+  parameters:
+    device_type:
+      name: device_type
+      description: One of the recognised ASCOM device types e.g. telescope (must be lower case)
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - camera
+          - covercalibrator
+          - dome
+          - filterwheel
+          - focuser
+          - observingconditions
+          - rotator
+          - safetymonitor
+          - switch
+          - telescope
+
+    device_number:
+      name: device_number
+      description: Zero based device number as set on the server (0 to 4294967295)
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: uint32
+        example: 0
+
+    ClientIDQuery:
+      name: ClientID
+      description: Client's unique ID. (1 to 4294967295). The client should choose a value at start-up, e.g. a random value between 1 and 65535, and send this on every transaction to associate entries in device logs with this particular client.  Zero is a reserved value that clients should not use.
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: uint32
+        example: 123
+        minimum: 1
+    ClientTransactionIDQuery:
+      name: ClientTransactionID
+      description: Client's transaction ID. (1 to 4294967295). The client should start this count at 1 and increment by one on each successive transaction. This will aid associating entries in device logs with corresponding entries in client side logs.  Zero is a reserved value that clients should not use.
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: uint32
+        example: 1234
+        minimum: 1
+    RightAscensionQuery:
+      name: RightAscension
+      in: query
+      required: true
+      schema:
+        $ref: '#/components/schemas/RightAscension'
+    DeclinationQuery:
+      name: Declination
+      in: query
+      required: true
+      schema:
+        $ref: '#/components/schemas/Declination'
+    AxisQuery:
+      name: Axis
+      in: query
+      required: true
+      schema:
+        $ref: '#/components/schemas/TelescopeAxis'
+    SwitchNumberQuery:
+      name: Id
+      description: The device number (0 to MaxSwitch - 1)
+      in: query
+      required: true
+      schema:
+        type: integer
+        format: int32
+        example: 0
+        minimum: 0
+  requestBodies:
+    put_devicetype_Devicenumber_commandrequest:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaRequest'
+              - properties:
+                  Command:
+                    description: The literal command string to be transmitted.
+                    type: string
+                  Raw:
+                    description: >-
+                      If set to true the string is transmitted 'as-is', if set to false then
+                      protocol framing characters may be added prior to transmission
+                    type: boolean
+                required:
+                  - Command
+                  - Raw
+    putStandardClientParameters:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/AlpacaRequest'
+    putDome_devicenumber_slewtoazimuth:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaRequest'
+              - properties:
+                  Azimuth:
+                    description: >-
+                      Target dome azimuth (degrees, North zero and increasing clockwise. i.e.,
+                      90 East, 180 South, 270 West)
+                    type: number
+                required:
+                  - Azimuth
+    putTelescope_devicenumber_slewtoaltaz:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaRequest'
+              - properties:
+                  Azimuth:
+                    description: 'Azimuth coordinate (degrees, North-referenced, positive East/clockwise)'
+                    type: number
+                  Altitude:
+                    description: 'Altitude coordinate (degrees, positive up)'
+                    type: number
+                required:
+                  - Azimuth
+                  - Altitude
+    putTelescope_devicenumber_slewtocoordinates:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaRequest'
+              - properties:
+                  RightAscension:
+                    $ref: '#/components/schemas/RightAscension'
+                  Declination:
+                    $ref: '#/components/schemas/Declination'
+                required:
+                  - RightAscension
+                  - Declination
+  responses:
+    MethodResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AlpacaResponse'
+    DeviceStateResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    description: Array of DeviceState objects
+                    type: array
+                    uniqueItems: true
+                    items:
+                      description: A DeviceState object representing an operational property of this device
+                      type: object
+                      properties:
+                        Name:
+                          description: The property name. The name casing must match the casing in the relevant interface definition.
+                          type: string
+                        Value:
+                          description: >
+                            The corresponding value of the named operational property. This is a dynamically-typed value that can hold one of several basic types
+                            including Int16, Int32, Single, Double, String, Boolean and DateTime (returned as an ISO 8601 format string).
+                            
+                            
+                            **NOTE** The data type must be the same as that returned by the operational property.
+                          oneOf:
+                            - type: string
+                              description: A string property value.
+                            - type: number
+                              description: A numeric property value.
+                            - type: boolean
+                              description: A boolean property value.
+                            - type: string
+                              description: A date-time string in ISO 8601 format.
+                              format: date-time
+                              pattern: '^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?Z$'
+                      required:
+                        - Name
+                        - Value
+    '400':
+      description: 'The device did not understand which operation was being requested or insufficient information was given to complete the operation. Check the error message for detailed information.'
+      content:
+        text/plain:
+          schema:
+            type: string
+            description: Error message describing why the command cannot be processed
+    '500':
+      description: 'Server internal error. Check the error message for detailed information.'
+      content:
+        text/plain:
+          schema:
+            type: string
+            description: Error message describing why the command cannot be processed
+    ImageArrayResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Type:
+                    type: integer
+                    format: int32
+                    const: 2
+                    description: Must always be 2 representing a 32bit integer.
+              - oneOf:
+                - title: SinglePlane
+                  description: Single-plane image array
+                  properties:
+                    Rank:
+                      type: integer
+                      format: int32
+                      const: 2
+                    Value:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: integer
+                          format: int32
+                          description: Integer values
+                - title: MultiPlane
+                  description: Multi-plane image array
+                  properties:
+                    Rank:
+                      type: integer
+                      format: int32
+                      const: 3
+                    Value:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: integer
+                            format: int32
+                            description: Integer values
+    ImageArrayVariantResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Type:
+                    description: Data type of image array pixel values.
+                    type: integer
+                    format: int32
+                    oneOf:
+                      - title: Unknown
+                        description: Unknown data type.
+                        const: 0
+                      - title: Short
+                        description: 16-bit integer data type.
+                        const: 1
+                      - title: Integer
+                        description: 32-bit integer data type.
+                        const: 2
+                      - title: Double
+                        description: Double precision floating point data type.
+                        const: 3
+              - oneOf:
+                - title: SinglePlane
+                  description: Single-plane image array
+                  properties:
+                    Rank:
+                      type: integer
+                      format: int32
+                      const: 2
+                    Value:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: number
+                          description: Integer or double pixel values
+                - title: MultiPlane
+                  description: Multi-plane image array
+                  properties:
+                    Rank:
+                      type: integer
+                      format: int32
+                      const: 3
+                    Value:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: number
+                            description: Integer or double pixel values
+    BoolResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: boolean
+                    description: True or False value
+    DoubleResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: number
+                    format: double
+                    description: Returned double value
+    IntResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: integer
+                    format: int32
+                    description: Returned integer value
+    IntMinimum1Response:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: integer
+                    format: int32
+                    minimum: 1
+                    description: Returned integer value
+    IntArrayResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: array
+                    items:
+                      type: integer
+                      format: int32
+                    description: Array of integer values.
+    StringResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: string
+                    description: String response from the device.
+    StringArrayResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: array
+                    items:
+                      type: string
+                    description: Array of string values.
+    AxisRatesResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    description: Array of AxisRate objects
+                    type: array
+                    minItems: 0
+                    uniqueItems: true
+                    items:
+                      $ref: '#/components/schemas/AxisRate'
+    DriveRateResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/DriveRate'
+    DriveRatesResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    description: Array of DriveRate values
+                    type: array
+                    minItems: 1
+                    uniqueItems: true
+                    items:
+                      $ref: '#/components/schemas/DriveRate'
+    RightAscensionResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/RightAscension'
+    DeclinationResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/Declination'
+    PierSideResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/PierSide'
+    TelescopeUTCDateResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/TelescopeUTCDate'
+    LastExposureStartTimeResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/LastExposureStartTime'
+    CameraStateResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/CameraState'
+    SensorTypeResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/SensorType'
+    ShutterStateResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/ShutterState'
+    CalibratorStatusResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/CalibratorStatus'
+    CoverStatusResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/CoverStatus'
+    AlignmentModeResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/AlignmentMode'
+    EquatorialCoordinateTypeResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    $ref: '#/components/schemas/EquatorialCoordinateType'
+    PercentIntResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                    maximum: 100
+                    description: Returned percentage value between 0 and 100.
+    PercentDoubleResponse:
+      description: Transaction complete or exception.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AlpacaResponse'
+              - properties:
+                  Value:
+                    type: number
+                    format: double
+                    minimum: 0
+                    maximum: 100
+                    description: Returned percentage value between 0 and 100.
+  schemas:
+    AxisRate:
+      description: Axis rate object
+      type: object
+      properties:
+        Maximum:
+          description: >-
+            The maximum rate (degrees per second). This must always be a positive
+            number. It indicates the maximum rate in either direction about the
+            axis.
+          type: number
+        Minimum:
+          description: >-
+            The minimum rate (degrees per second). This must always be a positive
+            number. It indicates the maximum rate in either direction about the
+            axis.
+          type: number
+      required:
+        - Maximum
+        - Minimum
+    AlpacaRequest:
+      type: object
+      properties:
+        ClientID:
+          description: Client's unique ID. (1 to 4294967295). The client should choose a value at start-up, e.g. a random value between 1 and 65535, and send this on every transaction to associate entries in device logs with this particular client.  Zero is a reserved value that clients should not use.
+          type: integer
+          format: uint32
+          minimum: 1
+        ClientTransactionID:
+          description: Client's transaction ID. (1 to 4294967295). The client should start this count at 1 and increment by one on each successive transaction. This will aid associating entries in device logs with corresponding entries in client side logs.  Zero is a reserved value that clients should not use.
+          type: integer
+          format: uint32
+          minimum: 1
+    AlpacaResponse:
+      type: object
+      properties:
+        ClientTransactionID:
+          type: integer
+          format: uint32
+          minimum: 1
+          description: Client's transaction ID (1 to 4294967295), as supplied by the client in the command request. Zero indicates that a valid value was not supplied.
+        ServerTransactionID:
+          type: integer
+          format: uint32
+          minimum: 1
+          description: >-
+            Server's transaction ID (1 to 4294967295), must be unique for each client transaction so that log messages on the client can be associated with logs on the device.
+            The server should start this count at 1 and increment by one on each successive transaction. Zero indicates that a valid value was not supplied.
+        ErrorNumber:
+          type: integer
+          format: int32
+          description: Zero for a successful transaction, or a non-zero integer (0x400 to 0xFFF) if the device encountered an issue.
+          oneOf:
+            - title: Success
+              description: Successful transaction.
+              const: 0
+            - title: Error
+              description: >
+                Error encountered.
+
+                Devices must use ASCOM reserved error numbers whenever appropriate so that clients can take informed actions. E.g. returning 0x401 (1025) to indicate that an invalid value was received (see Alpaca API definition and developer documentation for further information).
+              minimum: 0x400
+              maximum: 0xFFF
+              # Without this, Swagger reports minimum and maximum as `| number` which is confusing.
+              type: integer
+        ErrorMessage:
+          type: string
+          description: Empty string for a successful transaction, or a message describing the issue that was encountered. If an error message is returned, a non zero error number must also be returned.
+    DriveRate:
+      description: Integer value corresponding to one of the standard drive rates.
+      type: integer
+      format: int32
+      oneOf:
+        - title: Sidereal
+          description: Sidereal tracking rate (15.041 arcseconds per second).
+          const: 0
+        - title: Lunar
+          description: Lunar tracking rate (14.685 arcseconds per second).
+          const: 1
+        - title: Solar
+          description: Solar tracking rate (15.0 arcseconds per second).
+          const: 2
+        - title: King
+          description: King tracking rate (15.0369 arcseconds per second).
+          const: 3
+    TelescopeAxis:
+      description: The axis about which rate information is desired.
+      type: integer
+      format: int32
+      oneOf:
+        - title: Primary
+          const: 0
+        - title: Secondary
+          const: 1
+        - title: Tertiary
+          const: 2
+    RightAscension:
+      type: number
+      description: Right Ascension coordinate (0.0 to 23.99999999 hours)
+      example: 3.0
+      minimum: 0.0
+      maximum: 23.9999999999
+    Declination:
+      description: Declination coordinate (-90.0 to +90.0 degrees)
+      type: number
+      example: 0.0
+      minimum: -90.0
+      maximum: 90.0
+    PierSide:
+      type: integer
+      format: int32
+      description: Returned side of pier
+      oneOf:
+        - title: East
+          description: Normal pointing state - Mount on the East side of pier (looking West).
+          const: 0
+        - title: West
+          description: Through the pole pointing state - Mount on the West side of pier (looking East).
+          const: 1
+        - title: Unknown
+          description: Unknown or indeterminate.
+          const: -1
+    TelescopeUTCDate:
+      type: string
+      # The described date format is the same as the standard OpenAPI format.
+      # https://swagger.io/docs/specification/data-models/data-types/
+      format: date-time
+      pattern: '^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?Z$'
+      description: >-
+        The UTC date/time of the telescope's internal clock in ISO 8601 format including fractional seconds.
+        The general format (in Microsoft custom date format style) is yyyy-MM-ddTHH:mm:ss.fffffffZ, e.g. 2016-03-04T17:45:31.1234567Z or 2016-11-14T07:03:08.1234567Z.
+        Please note the compulsary trailing Z indicating the 'Zulu', UTC time zone.
+    LastExposureStartTime:
+      type: string
+      # Custom format for FITS standard date-time.
+      # Not defined in standard OpenAPI, but used by downstream tooling processing this YAML.
+      format: date-time-fits
+      pattern: '^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$'
+      description: >-
+        The UTC date/time of exposure start in the FITS-standard CCYY-MM-DDThh:mm:ss[.sss...] format.
+    CameraState:
+      description: Camera state
+      type: integer
+      format: int32
+      oneOf:
+        - title: Idle
+          description: At idle state, available to start exposure.
+          const: 0
+        - title: Waiting
+          description: Exposure started but waiting (for shutter, trigger, filter wheel, etc.).
+          const: 1
+        - title: Exposing
+          description: Exposure currently in progress.
+          const: 2
+        - title: Reading
+          description: Sensor array is being read out (digitized).
+          const: 3
+        - title: Download
+          description: Downloading data to host.
+          const: 4
+        - title: Error
+          description: Camera error condition serious enough to prevent further operations.
+          const: 5
+    GuideDirection:
+      description: The direction in which the guide-rate motion is to be made.
+      type: integer
+      format: int32
+      oneOf:
+        - title: North
+          const: 0
+        - title: South
+          const: 1
+        - title: East
+          const: 2
+        - title: West
+          const: 3
+    SensorType:
+      description: The type of sensor in the camera.
+      type: integer
+      format: int32
+      oneOf:
+        - title: Monochrome
+          description: Single-plane monochrome sensor.
+          const: 0
+        - title: Color
+          description: Multiple-plane color sensor.
+          const: 1
+        - title: RGGB
+          description: Single-plane Bayer matrix RGGB sensor.
+          const: 2
+        - title: CMYG
+          description: Single-plane Bayer matrix CMYG sensor.
+          const: 3
+        - title: CMYG2
+          description: Single-plane Bayer matrix CMYG2 sensor.
+          const: 4
+        - title: LRGB
+          description: Single-plane Bayer matrix LRGB sensor.
+          const: 5
+    ShutterState:
+      description: Indicates the current state of the shutter or roof.
+      type: integer
+      format: int32
+      oneOf:
+        - title: Open
+          description: The shutter or roof is open.
+          const: 0
+        - title: Closed
+          description: The shutter or roof is closed.
+          const: 1
+        - title: Opening
+          description: The shutter or roof is opening.
+          const: 2
+        - title: Closing
+          description: The shutter or roof is closing.
+          const: 3
+        - title: Error
+          description: The shutter or roof has encountered a problem.
+          const: 4
+    CalibratorStatus:
+      description: Describes the state of a calibration device.
+      type: integer
+      format: int32
+      oneOf:
+        - title: NotPresent
+          description: This device does not have a calibration capability.
+          const: 0
+        - title: Off
+          description: The calibrator is off.
+          const: 1
+        - title: NotReady
+          description: The calibrator is stabilising or is not yet in the commanded state.
+          const: 2
+        - title: Ready
+          description: The calibrator is ready for use.
+          const: 3
+        - title: Unknown
+          description: The calibrator state is unknown.
+          const: 4
+        - title: Error
+          description: The calibrator encountered an error when changing state.
+          const: 5
+    CoverStatus:
+      description: Describes the state of a telescope cover.
+      type: integer
+      format: int32
+      oneOf:
+        - title: NotPresent
+          description: This device does not have a cover that can be closed independently.
+          const: 0
+        - title: Closed
+          description: The cover is closed.
+          const: 1
+        - title: Moving
+          description: The cover is moving to a new position.
+          const: 2
+        - title: Open
+          description: The cover is open.
+          const: 3
+        - title: Unknown
+          description: The state of the cover is unknown.
+          const: 4
+        - title: Error
+          description: The device encountered an error when changing state.
+          const: 5
+    AlignmentMode:
+      description: The alignment mode (geometry) of the mount.
+      type: integer
+      format: int32
+      oneOf:
+        - title: AltAz
+          description: Altitude-Azimuth type mount.
+          const: 0
+        - title: Polar
+          description: Polar (equatorial) mount other than German equatorial.
+          const: 1
+        - title: GermanPolar
+          description: German equatorial type mount.
+          const: 2
+    EquatorialCoordinateType:
+      description: The equatorial coordinate system used by the mount.
+      type: integer
+      format: int32
+      oneOf:
+        - title: Other
+          description: Custom or unknown equinox and/or reference frame.
+          const: 0
+        - title: Topocentric
+          description: Topocentric coordinates.
+          const: 1
+        - title: J2000
+          description: J2000 equator/equinox.
+          const: 2
+        - title: J2050
+          description: J2050 equator/equinox.
+          const: 3
+        - title: B1950
+          description: B1950 equinox, FK4 reference frame.
+          const: 4


### PR DESCRIPTION
## Summary
- Vendor the upstream ASCOM Alpaca OpenAPI spec into the repo as the in-repo
  source of truth for driver development (`docs/AlpacaDeviceAPI_v1.yaml`,
  OpenAPI 3.1.1, MIT-licensed).
- Teach `/driver-build` to verify that spec is current on every run and to
  follow it exactly, with reinforced cross-driver (filter wheel) consistency.
- Codify the project's Semantic Versioning policy in `/commit` and `/submit-pr`.
- Docs/tooling only — no C++, no driver, no runtime change. Versioned `2.0.1`.

## Changes
- **Vendored spec** (docs): `docs/AlpacaDeviceAPI_v1.yaml` — the OpenAPI YAML
  behind https://ascom-standards.org/api/, committed so driver work builds
  against a pinned local contract.
- **/driver-build skill**: new Step 0 verifies the vendored spec against
  ascom-standards.org each run (line-ending-insensitive diff of version +
  endpoint set; re-downloads on a major change). Step 3 now drives off the
  vendored YAML to follow the API to the letter, and reinforces filter-wheel
  consistency with the ZWO EFW / Player One Phoenix setup.
- **/commit skill**: documents the SemVer policy (new driver = minor,
  fix/docs = patch, breaking = major) with cumulative carry-forward; `/commit`
  now only sets the CHANGELOG `UNRELEASED` heading and never edits `VERSION`
  or the README badge.
- **/submit-pr skill**: verifies the `UNRELEASED` version matches the policy
  for the branch, and asks whether the PR cuts a release — offering to bump
  the `VERSION` file and README version badge when it does.
- **Documentation**: `CHANGELOG.md` gains `## [2.0.1] - UNRELEASED`.

## Test plan
- [x] Local CI pre-flight green: unicode scan PASS, build+test vendors OFF/ON
      PASS, all other gates correctly skipped (no C/C++/shell/JS/workflow changes)
- [x] `/driver-build` Step 0 freshness check verified against live spec
      (reports CURRENT, no false positive across CRLF→LF normalization)

## Notes
Docs/tooling PR — not cutting a release. `2.0.1` stays `UNRELEASED`; `VERSION`
and the README badge are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)