### PR TITLE
Keep docs/architecture.md vendor table current via /commit

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -137,14 +137,16 @@ existing vendor, a new/updated vendor SDK, or a new wrapper).
      `ASIAIR power`; iOptron/ToupTek gaining a Switch driver, etc.). Be specific the way the
      existing cells are (note the model/subtype in parentheses where the table already does).
    - **Wrapper Type** — `SDK wrapper` for a vendor C library, `Protocol wrapper` for
-     serial/network, matching Layer 2 of the three-layer architecture.
+     serial/network/GPIO, matching Layer 2 of the three-layer architecture. Use
+     `SDK + protocol wrapper` when one vendor has both (e.g. ZWO and ToupTek — SDK-based
+     cameras plus a protocol/GPIO wrapper for their mount or PowerBox Switch).
    - **Status** — `In development` until the driver is ConformU-validated, then `Production`
      (keep it consistent with whether SUPPORTED-DRIVERS.md lists it as validated).
 3. If a **new vendor SDK directory** was added under `AlpacaCore/external/`, add it to the
    `external/` listing in the **Workspace structure** tree in the same doc.
-4. Keep the table consistent with the SUPPORTED-DRIVERS.md update from the top-level Step 4
-   above — they describe the same drivers from different angles and must not disagree about
-   which device types a vendor supports.
+4. Keep the table consistent with the SUPPORTED-DRIVERS.md table maintained in the
+   `## Step 4 — Update SUPPORTED-DRIVERS.md` section above — they describe the same drivers
+   from different angles and must not disagree about which device types a vendor supports.
 
 ## Step 5 — Update CHANGELOG.md
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -120,7 +120,10 @@ Driver Notes format:
 - **Tested model**: Model on Linux arm64
 ```
 
-### Also update docs/architecture.md (vendor / SDK table)
+## Step 4b — Also update docs/architecture.md (vendor / SDK table)
+
+**Action required whenever this commit adds or changes vendor/driver/SDK support** (same trigger
+as Step 4) — not just reference material.
 
 `docs/architecture.md` carries a **Vendor drivers** table (`Vendor | Device Types | Wrapper Type
 | Status`) and an `external/` SDK listing that are easy to leave behind. Whenever this commit

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -120,6 +120,31 @@ Driver Notes format:
 - **Tested model**: Model on Linux arm64
 ```
 
+### Also update docs/architecture.md (vendor / SDK table)
+
+`docs/architecture.md` carries a **Vendor drivers** table (`Vendor | Device Types | Wrapper Type
+| Status`) and an `external/` SDK listing that are easy to leave behind. Whenever this commit
+adds or changes vendor/driver/SDK support, bring that doc current in the **same commit** so it
+never drifts — the same trigger as SUPPORTED-DRIVERS.md (new vendor, new device type for an
+existing vendor, a new/updated vendor SDK, or a new wrapper).
+
+1. Read the **Vendor drivers** table in `docs/architecture.md`.
+2. Reconcile it against what's actually in the tree — derive the truth from
+   `ls AlpacaCore/src/vendors/*/` and the vendor's `external/` SDK dir, not from memory:
+   - **New vendor** → add a row.
+   - **New device type for an existing vendor** → add it to that vendor's **Device Types** cell
+     (e.g. Player One `Camera` → `Camera, FilterWheel, Switch`; ZWO Switch `dew heater` → also
+     `ASIAIR power`; iOptron/ToupTek gaining a Switch driver, etc.). Be specific the way the
+     existing cells are (note the model/subtype in parentheses where the table already does).
+   - **Wrapper Type** — `SDK wrapper` for a vendor C library, `Protocol wrapper` for
+     serial/network, matching Layer 2 of the three-layer architecture.
+   - **Status** — `In development` until the driver is ConformU-validated, then `Production`
+     (keep it consistent with whether SUPPORTED-DRIVERS.md lists it as validated).
+3. If a **new vendor SDK directory** was added under `AlpacaCore/external/`, add it to the
+   `external/` listing in the **Workspace structure** tree in the same doc.
+4. Keep the table consistent with SUPPORTED-DRIVERS.md (Step 4) — they describe the same drivers
+   from different angles and must not disagree about which device types a vendor supports.
+
 ## Step 5 — Update CHANGELOG.md
 
 Every commit that changes code or adds features should have a corresponding `CHANGELOG.md` entry. The project uses [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -142,8 +142,9 @@ existing vendor, a new/updated vendor SDK, or a new wrapper).
      (keep it consistent with whether SUPPORTED-DRIVERS.md lists it as validated).
 3. If a **new vendor SDK directory** was added under `AlpacaCore/external/`, add it to the
    `external/` listing in the **Workspace structure** tree in the same doc.
-4. Keep the table consistent with SUPPORTED-DRIVERS.md (Step 4) — they describe the same drivers
-   from different angles and must not disagree about which device types a vendor supports.
+4. Keep the table consistent with the SUPPORTED-DRIVERS.md update from the top-level Step 4
+   above — they describe the same drivers from different angles and must not disagree about
+   which device types a vendor supports.
 
 ## Step 5 — Update CHANGELOG.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
-## [2.0.1] - 2026-06-14
+## [2.0.2] - UNRELEASED
+
+### Changed
+- **`/commit` skill**: now also keeps `docs/architecture.md` current — Step 4 instructs it to update the **Vendor drivers** table (device types, wrapper type, status) and the `external/` SDK listing whenever a commit adds or changes vendor/driver/SDK support, deriving the truth from the source tree rather than memory.
+- **`docs/architecture.md`**: brought the **Vendor drivers** table up to date with all shipped drivers that had drifted out — Player One (FilterWheel, Switch), ZWO (ASIAIR-power Switch, AM-mount Telescope), ToupTek (AAF Focuser, StellaVita Switch), and iOptron (iMate PowerBox Switch); ZWO and ToupTek wrapper type noted as SDK + protocol.
+
+<details>
+<summary><strong>[2.0.1] - 2026-06-14</strong></summary>
 
 ### Added
 - **Vendored ASCOM Alpaca API spec** (docs): the upstream OpenAPI YAML behind https://ascom-standards.org/api/ is now committed at `docs/AlpacaDeviceAPI_v1.yaml` (OpenAPI 3.1.1, MIT-licensed) as the in-repo source of truth for driver development.
@@ -22,6 +29,8 @@ AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and
 
 ### Fixed
 - **GPIO Switch drivers failed to connect under the systemd service** (debian/packaging): the `.deb` postinst added the `alpacabridge` service user to `plugdev`/`dialout`/`input` but not `gpio`, so the libgpiod-based Switch drivers — iOptron iMate PowerBox, ToupTek StellaVita, and ZWO ASIAIR Pro / Plus (Pi CM4) — got `Permission denied` opening `/dev/gpiochip*` (owned `root:gpio` by the OpenAstro images' udev rule) and Switch connect failed with "Failed to open GPIO chip ...". The postinst now also runs `usermod -aG gpio alpacabridge` (guarded by `getent group gpio`, matching the existing group grants); `dh_installsystemd` restarts the service after upgrade so the new membership takes effect without a manual restart. Only affected the packaged service user — dev runs via `build_and_run.sh` already add the invoking user to `gpio`.
+
+</details>
 
 <details>
 <summary><strong>[2.0.0] - 2026-06-13</strong></summary>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ All interfaces inherit from `AlpacaDriver` which provides device information, co
 - Isolates SDK dependencies from core code
 - Only place where vendor SDK headers are included
 
-Drivers that talk to hardware via a vendor C library use an **SDK wrapper** (ZWO, QHY, Player One, SVBONY, ToupTek). Drivers that talk over serial/network protocols use a **protocol wrapper** (iOptron, SynScan, Celestron, Losmandy Gemini).
+Drivers that talk to hardware via a vendor C library use an **SDK wrapper** (QHY, Player One, SVBONY; ZWO and ToupTek for their cameras/focusers). Drivers that talk over serial, network, or GPIO use a **protocol wrapper** (iOptron, SynScan, Celestron, Losmandy Gemini; ZWO for the AM mount and ASIAIR power Switch; ToupTek for the StellaVita Switch). ZWO and ToupTek therefore use both — hence "SDK + protocol wrapper" in the table above.
 
 #### Layer 3: Vendor implementation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,12 +105,12 @@ See the [Development Guide](development.md) for step-by-step implementation.
 
 | Vendor | Device Types | Wrapper Type | Status |
 |--------|-------------|--------------|--------|
-| ZWO | Camera, Focuser (EAF), Rotator (CAA), Switch (dew heater), FilterWheel (EFW) | SDK wrapper | Production |
+| ZWO | Camera, Focuser (EAF), Rotator (CAA), FilterWheel (EFW), Switch (dew heater, ASIAIR power), Telescope (AM mount) | SDK + protocol wrapper | Production |
 | QHY | Camera | SDK wrapper | Production |
-| Player One | Camera | SDK wrapper | Production |
+| Player One | Camera, FilterWheel (Phoenix Wheel), Switch (dew heater + fan) | SDK wrapper | Production |
 | SVBONY | Camera | SDK wrapper | Production |
-| ToupTek | Camera | SDK wrapper | Production |
-| iOptron | Telescope | Protocol wrapper | Production |
+| ToupTek | Camera, Focuser (AAF), Switch (StellaVita power) | SDK + protocol wrapper | Production |
+| iOptron | Telescope, Switch (iMate PowerBox) | Protocol wrapper | Production |
 | SynScan | Telescope | Protocol wrapper | Production |
 | Celestron | Telescope | Protocol wrapper | Production |
 | Losmandy Gemini | Focuser | Protocol wrapper | Production |


### PR DESCRIPTION
## Summary
- The `docs/architecture.md` Vendor drivers table had drifted behind the shipped drivers.
- Bring it current, and wire the `/commit` skill to maintain it going forward so it doesn't drift again.
- Docs/tooling only — no code, no runtime change. Versioned 2.0.2.

## Changes
- **/commit skill** (`.claude/commands/commit.md`): Step 4 now also updates `docs/architecture.md` — the Vendor drivers table (device types, wrapper type, status) and the `external/` SDK listing — whenever a commit adds or changes vendor/driver/SDK support, deriving the truth from `AlpacaCore/src/vendors/*/` and the `external/` dir rather than memory, and kept consistent with SUPPORTED-DRIVERS.md.
- **docs/architecture.md**: Vendor drivers table reconciled with the tree — Player One (+ FilterWheel, + Switch), ZWO (+ ASIAIR-power Switch, + AM-mount Telescope), ToupTek (+ AAF Focuser, + StellaVita Switch), iOptron (+ iMate PowerBox Switch); ZWO and ToupTek wrapper type updated to "SDK + protocol".
- **CHANGELOG.md**: open `[2.0.2] - UNRELEASED` (2.0.1 collapsed per the convention).

## Test plan
- [x] Local CI pre-flight green: unicode scan PASS, build+test vendors OFF/ON PASS; all other gates skipped (no C/C++/shell/JS/workflow changes)
- [x] Table cross-checked against `ls AlpacaCore/src/vendors/*/` and `AlpacaCore/external/`

## Notes
Docs/tooling PR — not cutting a release. `2.0.2` stays UNRELEASED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)