### PR TITLE
Fix per-vendor camera/focuser index collision and auto-increment

### DIFF
--- a/.claude/commands/driver-build.md
+++ b/.claude/commands/driver-build.md
@@ -435,21 +435,34 @@ Checklist:
 
 ## Step 6 — AlpacaHTTP integration
 
-All 8 steps required for end-to-end functionality:
+All 9 steps required for end-to-end functionality:
 1. Router registration in `AlpacaHTTP/src/http/router.cpp`.
 2. Router includes with `#ifdef ALPACACORE_ENABLE_<VENDOR>` guard.
 3. Config sanitization fields preserved.
 4. Web UI vendor dropdown in `AlpacaHTTP/web/app.js`.
 5. Web UI vendor-specific form fields.
+   - **Unique vendor-prefixed `name` on EVERY field** (not just filter wheels): hidden
+     vendor sections still submit, so a generic `name` like `cameraIndex`/`focuserIndex`
+     collides in `FormData` with ZWO's same-named field (first in DOM wins) and the value
+     you typed is silently dropped — `0` gets saved. Name non-ZWO fields like
+     `playerOneCameraIndex`, `qhyCameraIndex`, `touptekFocuserIndex`, and read that exact
+     name in the submit handler. Element `id`s stay descriptive; only the `name` must be
+     unique. (ZWO keeps the bare names as the canonical first block.)
    - **FilterWheel vendors**: the form MUST include the standard slot UI — a slot-count
      select listing the manufacturer's actual lineup (from Question 4b) plus Custom,
      per-slot filter name dropdowns, and the advanced names textarea. Instantiate
      `createFilterwheelSlotUI({...})` in `app.js` with vendor-prefixed element IDs and
-     copy the markup pattern from an existing filterwheel vendor in `index.html`. Use
-     vendor-prefixed form field names to avoid FormData collisions.
-6. Frontend validation logic.
-7. Build-flag propagation from AlpacaCore to AlpacaHTTP.
-8. Routing/config tests in `AlpacaHTTP/tests/`.
+     copy the markup pattern from an existing filterwheel vendor in `index.html`.
+6. Web UI index auto-numbering — for any SDK-enumeration index field (camera/focuser/
+   filterwheel/rotator), add an entry to the `INDEX_FIELDS` array in `app.js`
+   (`fieldId`, `vendor`, `deviceType`, `configKey`, optional `idFieldId`). That wires up
+   per-`(vendor, deviceType)` auto-increment and manual-edit tracking, so a second device
+   of the same vendor/type doesn't silently reuse index 0. (Distinct from the Alpaca
+   device number, which auto-assigns per type already.) See "Enumeration index fields" in
+   AGENTS.md.
+7. Frontend validation logic.
+8. Build-flag propagation from AlpacaCore to AlpacaHTTP.
+9. Routing/config tests in `AlpacaHTTP/tests/`.
 
 ## Step 7 — Tests (MANDATORY — do not skip)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,11 +144,12 @@ When adding a new vendor/device type in AlpacaCore, also update AlpacaHTTP:
 3. **Config sanitization fields** — ensure vendor-specific config keys are preserved through sanitization.
 4. **Web UI vendor dropdown** — add the vendor to the device-type dropdown in the web frontend (`AlpacaHTTP/web/app.js`) so users can select it.
 5. **Web UI vendor-specific form fields** — add any vendor-specific configuration fields (e.g. serial port, camera index, connection type) to the frontend form.
-6. **Frontend validation** — add any related validation logic in frontend JS.
-7. **Build-flag propagation** — ensure `ALPACACORE_ENABLE_<VENDOR>` compile definitions propagate from AlpacaCore to AlpacaHTTP.
-8. **Routing/config tests** — add or update tests in `AlpacaHTTP/tests/`.
+6. **Web UI index fields** — if the vendor connects by an SDK enumeration index, give each index input a **unique vendor-prefixed `name`** and register it in the `INDEX_FIELDS` array so auto-numbering and manual-edit tracking work. Both are mandatory and easy to miss — see "Enumeration index fields" below for the full rationale (a generic `name` silently saves 0; a missing registry entry reuses index 0 on the next device).
+7. **Frontend validation** — add any related validation logic in frontend JS.
+8. **Build-flag propagation** — ensure `ALPACACORE_ENABLE_<VENDOR>` compile definitions propagate from AlpacaCore to AlpacaHTTP.
+9. **Routing/config tests** — add or update tests in `AlpacaHTTP/tests/`.
 
-Vendor registration alone is not enough for HTTP/UI visibility. All eight steps must be completed for a new vendor/device to be fully functional end-to-end.
+Vendor registration alone is not enough for HTTP/UI visibility. All nine steps must be completed for a new vendor/device to be fully functional end-to-end.
 
 ### FilterWheel vendors — required web UI (slot count + filter name pickers)
 
@@ -170,6 +171,33 @@ sync; the form submit reads the textarea.
   hidden-but-enabled fields (ZWO's `filterwheelIndex` shadows any later duplicate).
 - When editing an existing device, populate the textarea from `config.filterNames` and
   call the instance's `syncSlotsFromTextarea()` so the dropdowns reflect the saved names.
+
+### Enumeration index fields — unique names + auto-numbering (all vendors)
+
+Many vendors connect by an SDK **enumeration index** (camera/focuser/filterwheel/rotator
+index — "which unit on the bus", numbered from 0). Two rules keep these working; a new
+vendor that ignores either ships a silently broken form:
+
+- **Each index input MUST have a unique, vendor-prefixed `name`** — e.g.
+  `playerOneCameraIndex`, `qhyCameraIndex`, `touptekFocuserIndex`, `geminiFocuserIndex` —
+  and the submit handler MUST read that exact name. Hidden vendor sections are **not**
+  disabled, so every index input is still in the form's `FormData`. A generic `name` like
+  `cameraIndex`/`focuserIndex` collides: `formData.get('cameraIndex')` returns the **first**
+  such field in DOM order (ZWO's, which appears first), so the value you typed into a
+  later vendor's field is discarded and `0` is saved instead. This is exactly why a
+  Player One/QHY/SVBONY/ToupTek camera index could not be changed from 0. ZWO keeps the
+  bare `cameraIndex`/`focuserIndex`/`filterwheelIndex`/`rotatorIndex` names (it's the
+  canonical first block); **every other vendor must prefix**. Element `id`s can stay
+  descriptive (`playerone-camera-index`) — `setFormValue`/auto-fill key off `id`, the
+  collision is purely about the `name` used in `FormData`.
+- **Register the field in the `INDEX_FIELDS` array** in `AlpacaHTTP/web/app.js`
+  (`fieldId`, `vendor`, `deviceType`, `configKey`, optional `idFieldId`). That one entry
+  drives auto-increment (so a second device of the same vendor/type doesn't reuse index 0)
+  **and** the manual-edit tracking. The index is scoped per `(vendor, deviceType)` — each
+  SDK enumerates from 0 independently, so a ZWO camera and a Player One camera are both
+  index 0. This is distinct from the Alpaca **device number** (auto-assigned per device
+  type, vendor-agnostic, and what clients address). Serial/network devices (port path or
+  host) have no index and belong in neither place.
 
 ## Alpaca Protocol Conformance (AlpacaHTTP)
 

--- a/AlpacaHTTP/web/app.js
+++ b/AlpacaHTTP/web/app.js
@@ -284,17 +284,45 @@ function getNextDeviceNumberForType(deviceType) {
     return getNextAvailableNumber(used);
 }
 
-function getNextZwoCameraIndex() {
+// Index-addressed config fields that auto-increment per (vendor, deviceType).
+//
+// The Alpaca device *number* (handled above, vendor-agnostic per type) is how a
+// client addresses a device. A vendor *index* is different: it selects which
+// physical unit a vendor SDK enumerates on the bus (camera 0, 1, 2 ...). Each
+// SDK counts from 0 independently, so the index is scoped per (vendor,
+// deviceType) — a ZWO camera and a Player One camera can both be index 0.
+// Vendors that connect by serial port or network (iOptron, SynScan, Celestron,
+// Bisque) identify the device by path/host and have no index field, so they
+// aren't listed here. `idFieldId`, when present, is a serial/ID input that pins
+// a specific unit; if the user filled it, we don't impose an auto index.
+const INDEX_FIELDS = [
+    { fieldId: 'camera-index', vendor: 'zwo', deviceType: 'camera', configKey: 'cameraIndex', idFieldId: 'camera-id' },
+    { fieldId: 'filterwheel-index', vendor: 'zwo', deviceType: 'filterwheel', configKey: 'filterwheelIndex', idFieldId: 'filterwheel-id' },
+    { fieldId: 'focuser-index', vendor: 'zwo', deviceType: 'focuser', configKey: 'focuserIndex', idFieldId: 'focuser-id' },
+    { fieldId: 'rotator-index', vendor: 'zwo', deviceType: 'rotator', configKey: 'rotatorIndex', idFieldId: 'rotator-id' },
+    { fieldId: 'qhy-camera-index', vendor: 'qhy', deviceType: 'camera', configKey: 'cameraIndex' },
+    { fieldId: 'svbony-camera-index', vendor: 'svbony', deviceType: 'camera', configKey: 'cameraIndex' },
+    { fieldId: 'touptek-camera-index', vendor: 'touptek', deviceType: 'camera', configKey: 'cameraIndex' },
+    { fieldId: 'touptek-focuser-index', vendor: 'touptek', deviceType: 'focuser', configKey: 'focuserIndex', idFieldId: 'touptek-focuser-id' },
+    { fieldId: 'playerone-camera-index', vendor: 'playerone', deviceType: 'camera', configKey: 'cameraIndex' },
+    { fieldId: 'playerone-filterwheel-index', vendor: 'playerone', deviceType: 'filterwheel', configKey: 'filterwheelIndex' },
+    { fieldId: 'gemini-focuser-index', vendor: 'gemini', deviceType: 'focuser', configKey: 'focuserIndex' },
+];
+
+// Lowest unused value of field.configKey across already-configured devices that
+// match this field's (vendor, deviceType). Each SDK enumerates from 0, so the
+// scan is intentionally scoped to the same vendor and type.
+function getNextIndexForField(field) {
     const used = new Set();
     currentDevices.forEach(device => {
-        const vendor = extractVendor(device);
-        const type = extractDeviceType(device);
-        if (vendor !== 'zwo' || type !== 'camera') {
+        if (extractVendor(device) !== field.vendor) {
+            return;
+        }
+        if (extractDeviceType(device) !== field.deviceType) {
             return;
         }
         const config = extractDeviceConfig(device);
-        const indexValue = config && config.cameraIndex;
-        const parsed = Number.parseInt(indexValue, 10);
+        const parsed = Number.parseInt(config && config[field.configKey], 10);
         if (!Number.isNaN(parsed) && parsed >= 0) {
             used.add(parsed);
         }
@@ -322,37 +350,43 @@ function maybeAutoFillDeviceNumber() {
     deviceNumberInput.value = nextNumber;
 }
 
-function maybeAutoFillZwoCameraIndex() {
+// Auto-fill the vendor index field(s) for the currently selected vendor +
+// device type, so adding a second device of the same vendor/type doesn't
+// silently reuse index 0. Skips a field the user has edited, or whose
+// serial/ID twin is filled in (the ID pins the unit, making the index moot).
+function maybeAutoFillIndexFields() {
     const form = document.getElementById('device-form');
     const vendorSelect = document.getElementById('vendor');
     const deviceTypeSelect = document.getElementById('device-type');
-    const cameraIndexInput = document.getElementById('camera-index');
-    const cameraIdInput = document.getElementById('camera-id');
-    if (!form || !vendorSelect || !deviceTypeSelect || !cameraIndexInput) {
+    if (!form || !vendorSelect || !deviceTypeSelect) {
         return;
     }
     if (form.dataset.editing === 'true') {
         return;
     }
-    if (vendorSelect.value !== 'zwo' || normalizeDeviceType(deviceTypeSelect.value) !== 'camera') {
-        return;
-    }
-    if (cameraIdInput && cameraIdInput.value.trim() !== '') {
-        return;
-    }
-    if (cameraIndexInput.dataset.userModified === 'true') {
-        return;
-    }
-    const nextIndex = getNextZwoCameraIndex();
-    if (nextIndex === null) {
-        return;
-    }
-    cameraIndexInput.value = nextIndex;
+    const vendor = vendorSelect.value;
+    const deviceType = normalizeDeviceType(deviceTypeSelect.value);
+    INDEX_FIELDS.forEach(field => {
+        if (field.vendor !== vendor || field.deviceType !== deviceType) {
+            return;
+        }
+        const input = document.getElementById(field.fieldId);
+        if (!input || input.dataset.userModified === 'true') {
+            return;
+        }
+        if (field.idFieldId) {
+            const idInput = document.getElementById(field.idFieldId);
+            if (idInput && idInput.value.trim() !== '') {
+                return;
+            }
+        }
+        input.value = getNextIndexForField(field);
+    });
 }
 
 function updateAutoNumbering() {
     maybeAutoFillDeviceNumber();
-    maybeAutoFillZwoCameraIndex();
+    maybeAutoFillIndexFields();
 }
 
 // Load devices
@@ -555,13 +589,18 @@ function setEditMode(isEditing) {
             delete form.dataset.originalDeviceNumber;
             delete form.dataset.originalVendor;
             const deviceNumberInput = document.getElementById('device-number');
-            const cameraIndexInput = document.getElementById('camera-index');
             if (deviceNumberInput) {
                 delete deviceNumberInput.dataset.userModified;
             }
-            if (cameraIndexInput) {
-                delete cameraIndexInput.dataset.userModified;
-            }
+            // Clear the manual-edit flag on every vendor index field so the next
+            // fresh "Add Device" re-derives them instead of treating a prior
+            // edit's value as user-pinned.
+            INDEX_FIELDS.forEach(field => {
+                const input = document.getElementById(field.fieldId);
+                if (input) {
+                    delete input.dataset.userModified;
+                }
+            });
             updateAutoNumbering();
         }
     }
@@ -1716,19 +1755,17 @@ if (deviceNumberInput) {
     });
 }
 
-const cameraIndexInput = document.getElementById('camera-index');
-if (cameraIndexInput) {
-    cameraIndexInput.addEventListener('input', () => {
-        cameraIndexInput.dataset.userModified = 'true';
-    });
-}
-
-const filterwheelIndexInput = document.getElementById('filterwheel-index');
-if (filterwheelIndexInput) {
-    filterwheelIndexInput.addEventListener('input', () => {
-        filterwheelIndexInput.dataset.userModified = 'true';
-    });
-}
+// Mark any vendor index field as user-modified once edited, so auto-numbering
+// leaves it alone. Driven off INDEX_FIELDS so every vendor's index field
+// (not just ZWO's) is covered.
+INDEX_FIELDS.forEach(field => {
+    const input = document.getElementById(field.fieldId);
+    if (input) {
+        input.addEventListener('input', () => {
+            input.dataset.userModified = 'true';
+        });
+    }
+});
 
 // Slot-count + per-slot filter name pickers. Every filterwheel vendor config
 // gets an instance (see AGENTS.md "FilterWheel web UI" note); the factory
@@ -1746,20 +1783,6 @@ const playerOneFilterwheelSlotUI = createFilterwheelSlotUI({
     slotListId: 'playerone-filterwheel-slot-list',
     namesTextareaId: 'playerone-filter-names'
 });
-
-const focuserIndexInput = document.getElementById('focuser-index');
-if (focuserIndexInput) {
-    focuserIndexInput.addEventListener('input', () => {
-        focuserIndexInput.dataset.userModified = 'true';
-    });
-}
-
-const rotatorIndexInput = document.getElementById('rotator-index');
-if (rotatorIndexInput) {
-    rotatorIndexInput.addEventListener('input', () => {
-        rotatorIndexInput.dataset.userModified = 'true';
-    });
-}
 
 const apertureDiameterInput = document.getElementById('aperture-diameter');
 if (apertureDiameterInput) {
@@ -2450,11 +2473,11 @@ document.getElementById('device-form').addEventListener('submit', async function
         if (qhyCameraId && qhyCameraId.trim() !== '') {
             deviceData.cameraId = qhyCameraId.trim();
         } else {
-            const qhyCameraIndex = readOptionalNumber(formData, 'cameraIndex');
+            const qhyCameraIndex = readOptionalNumber(formData, 'qhyCameraIndex');
             deviceData.cameraIndex = qhyCameraIndex !== null ? qhyCameraIndex : 0;
         }
     } else if (deviceData.vendor === 'svbony') {
-        const svbonyCameraIndex = readOptionalNumber(formData, 'cameraIndex');
+        const svbonyCameraIndex = readOptionalNumber(formData, 'svbonyCameraIndex');
         deviceData.cameraIndex = svbonyCameraIndex !== null ? svbonyCameraIndex : 0;
     } else if (deviceData.vendor === 'touptek' && normalizeDeviceType(deviceData.deviceType) === 'switch') {
         // StellaVita PowerBox: local GPIO, no camera/focuser index. Optional
@@ -2486,11 +2509,11 @@ document.getElementById('device-form').addEventListener('submit', async function
             if (touptekFocuserId && touptekFocuserId.trim() !== '') {
                 deviceData.focuserId = touptekFocuserId.trim();
             } else {
-                const touptekFocuserIndex = readOptionalNumber(formData, 'focuserIndex');
+                const touptekFocuserIndex = readOptionalNumber(formData, 'touptekFocuserIndex');
                 deviceData.focuserIndex = touptekFocuserIndex !== null ? touptekFocuserIndex : 0;
             }
         } else {
-            const touptekCameraIndex = readOptionalNumber(formData, 'cameraIndex');
+            const touptekCameraIndex = readOptionalNumber(formData, 'touptekCameraIndex');
             deviceData.cameraIndex = touptekCameraIndex !== null ? touptekCameraIndex : 0;
         }
     } else if (deviceData.vendor === 'playerone') {
@@ -2505,7 +2528,7 @@ document.getElementById('device-form').addEventListener('submit', async function
             const playerOneSwitchCameraIndex = readOptionalNumber(formData, 'playerOneSwitchCameraIndex');
             deviceData.cameraIndex = playerOneSwitchCameraIndex !== null ? playerOneSwitchCameraIndex : 0;
         } else {
-            const playerOneCameraIndex = readOptionalNumber(formData, 'cameraIndex');
+            const playerOneCameraIndex = readOptionalNumber(formData, 'playerOneCameraIndex');
             deviceData.cameraIndex = playerOneCameraIndex !== null ? playerOneCameraIndex : 0;
         }
     } else if (deviceData.vendor === 'weewx') {
@@ -2522,7 +2545,7 @@ document.getElementById('device-form').addEventListener('submit', async function
         const geminiConnType = document.getElementById('gemini-connection-type');
         deviceData.connectionType = geminiConnType ? geminiConnType.value : 'auto';
         if (deviceData.connectionType === 'auto') {
-            const focuserIndex = readOptionalNumber(formData, 'focuserIndex');
+            const focuserIndex = readOptionalNumber(formData, 'geminiFocuserIndex');
             deviceData.focuserIndex = focuserIndex !== null ? focuserIndex : 0;
         } else if (deviceData.connectionType === 'serial') {
             deviceData.portPath = formData.get('portPath') || '';

--- a/AlpacaHTTP/web/index.html
+++ b/AlpacaHTTP/web/index.html
@@ -586,7 +586,7 @@
                     <div id="playerone-camera-fields">
                         <div class="form-group">
                             <label for="playerone-camera-index">Camera Index:</label>
-                            <input type="number" id="playerone-camera-index" name="cameraIndex" value="0" min="0">
+                            <input type="number" id="playerone-camera-index" name="playerOneCameraIndex" value="0" min="0">
                             <small>0-based index from the Player One SDK enumeration.</small>
                         </div>
                     </div>
@@ -638,7 +638,7 @@
 
                     <div class="form-group">
                         <label for="qhy-camera-index">Camera Index:</label>
-                        <input type="number" id="qhy-camera-index" name="cameraIndex" value="0" min="0">
+                        <input type="number" id="qhy-camera-index" name="qhyCameraIndex" value="0" min="0">
                         <small>0-based index from the QHY SDK enumeration.</small>
                     </div>
 
@@ -650,7 +650,7 @@
 
                     <div class="form-group">
                         <label for="svbony-camera-index">Camera Index:</label>
-                        <input type="number" id="svbony-camera-index" name="cameraIndex" value="0" min="0">
+                        <input type="number" id="svbony-camera-index" name="svbonyCameraIndex" value="0" min="0">
                         <small>0-based index from the SVBONY SDK enumeration.</small>
                     </div>
 
@@ -663,7 +663,7 @@
                     <div id="touptek-camera-fields">
                         <div class="form-group">
                             <label for="touptek-camera-index">Camera Index:</label>
-                            <input type="number" id="touptek-camera-index" name="cameraIndex" value="0" min="0">
+                            <input type="number" id="touptek-camera-index" name="touptekCameraIndex" value="0" min="0">
                             <small>0-based index from the ToupTek SDK enumeration.</small>
                         </div>
                     </div>
@@ -671,7 +671,7 @@
                     <div id="touptek-focuser-fields" style="display: none;">
                         <div class="form-group">
                             <label for="touptek-focuser-index">Focuser Index:</label>
-                            <input type="number" id="touptek-focuser-index" name="focuserIndex" value="0" min="0">
+                            <input type="number" id="touptek-focuser-index" name="touptekFocuserIndex" value="0" min="0">
                             <small>0-based index among ToupTek AAF (Astro Auto Focuser) devices.</small>
                         </div>
                         <div class="form-group">
@@ -773,7 +773,7 @@
                     <div id="gemini-auto-fields">
                         <div class="form-group">
                             <label for="gemini-focuser-index">Focuser Index:</label>
-                            <input type="number" id="gemini-focuser-index" name="focuserIndex" value="0" min="0">
+                            <input type="number" id="gemini-focuser-index" name="geminiFocuserIndex" value="0" min="0">
                             <small>0-based index if multiple focusers are detected. Usually 0.</small>
                         </div>
                     </div>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
-## [2.0.2] - 2026-06-16
+## [2.0.3] - UNRELEASED
+
+### Fixed
+- **Vendor index fields could not be set to anything but 0** (AlpacaHTTP web UI): every camera index input shared `name="cameraIndex"` (and three focuser inputs shared `name="focuserIndex"`). Hidden vendor sections still submit, so `formData.get('cameraIndex')` always returned the first such field in DOM order — ZWO's — and the value typed into a Player One / QHY / SVBONY / ToupTek (or Gemini focuser) field was discarded, persisting `0`. Adding a second device of one of those vendors silently collided on index 0, and the index could not be corrected in the form. Each non-ZWO index input now has a unique vendor-prefixed `name` (`playerOneCameraIndex`, `qhyCameraIndex`, `svbonyCameraIndex`, `touptekCameraIndex`, `touptekFocuserIndex`, `geminiFocuserIndex`) and the submit handler reads it; ZWO keeps the canonical names. Same FormData-collision class already documented for filter names.
+- **Camera index did not auto-increment for non-ZWO vendors** (AlpacaHTTP web UI): auto-numbering was hardcoded to ZWO's camera field, so a second Player One/QHY/SVBONY/ToupTek camera (and ZWO focuser/filterwheel/rotator) defaulted to index 0 instead of the next free value. Replaced the ZWO-only logic with a declarative `INDEX_FIELDS` registry that drives per-`(vendor, deviceType)` auto-increment, manual-edit tracking, and the edit-mode reset for all index-addressed fields. The index is scoped per vendor SDK (each enumerates from 0 independently, so a ZWO camera and a Player One camera are both index 0); this is distinct from the Alpaca device number, which already auto-assigns per device type.
+
+### Changed
+- **`AGENTS.md` + `/driver-build` skill**: documented the two rules a new index-addressed vendor must follow — a unique vendor-prefixed form-field `name` (to avoid the FormData collision above) and an `INDEX_FIELDS` registry entry (for auto-numbering) — with the device-number-vs-index distinction spelled out, so this doesn't resurface when the next camera/focuser is added.
+
+<details>
+<summary><strong>[2.0.2] - 2026-06-16</strong></summary>
 
 ### Changed
 - **`/commit` skill**: now also keeps `docs/architecture.md` current — Step 4 instructs it to update the **Vendor drivers** table (device types, wrapper type, status) and the `external/` SDK listing whenever a commit adds or changes vendor/driver/SDK support, deriving the truth from the source tree rather than memory.
@@ -17,6 +27,8 @@ AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and
 
 ### Fixed
 - **Configure tab kept a previous device's settings** (AlpacaHTTP web UI): the device form was only cleared on a successful submit, so after editing or partially filling a device, opening the **Configure** tab to add a new one still showed the old vendor, indexes, ports, filter names, and the "Edit Device" / "Update Device" mode — and submitting from that leaked edit state would remove-and-re-add the wrong device. Opening the Configure tab fresh now resets the form to a clean "Add Device" state via a new `resetDeviceForm()` (native reset, edit mode cleared, vendor sub-sections re-toggled, ZWO/Player One filter-wheel slot UIs resynced); the edit flow switches tabs with `showTab('configure', { preserveForm: true })` so the populated form it just built survives. `showTab` now marks the active tab button by name instead of relying on the global `event`, so the post-submit `showTab('devices')` no longer depends on a stale `event.target`.
+
+</details>
 
 <details>
 <summary><strong>[2.0.1] - 2026-06-14</strong></summary>


### PR DESCRIPTION
## Summary
- Fixes two web UI bugs around vendor enumeration indexes (camera / focuser / filterwheel / rotator):
  1. **Non-ZWO indexes couldn't be set at all** — five camera inputs shared `name="cameraIndex"` (and three focuser inputs shared `name="focuserIndex"`), so hidden vendor sections collided in `FormData`, the first field (ZWO's) won, and the typed value was dropped — `0` was always saved.
  2. **Indexes didn't auto-increment for non-ZWO vendors** — auto-numbering was hardcoded to ZWO's camera field, so a second Player One/QHY/SVBONY/ToupTek camera defaulted to index 0 instead of the next free value.
- No driver/SDK/protocol changes; web UI + docs only.

## Changes
- **Web UI** (AlpacaHTTP `index.html` + `app.js`): unique vendor-prefixed `name` on every non-ZWO index input (`playerOneCameraIndex`, `qhyCameraIndex`, `svbonyCameraIndex`, `touptekCameraIndex`, `touptekFocuserIndex`, `geminiFocuserIndex`), with the submit handler reading each unique name. ZWO keeps the canonical names.
- **Web UI** (AlpacaHTTP `app.js`): new declarative `INDEX_FIELDS` registry driving per-`(vendor, deviceType)` auto-increment, manual-edit tracking, and edit-mode reset for all index-addressed fields. Index is scoped per vendor SDK (each enumerates from 0 independently); distinct from the Alpaca device number, which already auto-assigns per type.
- **Documentation**: `AGENTS.md` + `/driver-build` skill document both rules (unique field name + `INDEX_FIELDS` entry) so a new index-addressed vendor can't reintroduce either bug. CHANGELOG `2.0.3` UNRELEASED entries.

## Test plan
- [x] Local CI pre-flight green: build+test (vendors OFF + ON), unicode scan, `node --check` on `web/app.js`
- [x] Logic validated against a live `configureddevices` payload (per-vendor enumeration, per-type separation, gap-filling)
- [ ] Web UI manual check: add a 2nd Player One camera -> index auto-fills to 1; edit a non-ZWO camera and set a non-zero index -> it persists (no longer forced to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)