### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
-## [3.0.0] - UNRELEASED
+## [3.0.0] - 2026-07-06
 
 ### Added
 - **ThreadSanitizer CI job + per-driver concurrency stress harness** (#101): a new `sanitizers-tsan` CI job builds the all-vendors AlpacaCore tests with `-fsanitize=thread` and runs a new `[stress]` suite — the first automated coverage for the #1 driver-review bug class (use-after-close, dropped racing disconnects, destructor vs connection-thread races), which the single-threaded ASan job and ConformU cannot see. The reusable harness (`AlpacaCore/tests/concurrency_stress.h`) provides three scenarios per driver: a lifecycle storm (async connect/disconnect + sync `set_connected` + status reads + operational calls from N threads), destruction racing an in-flight connect (the issue-#100 `std::terminate` class), and a deterministic racing-disconnect-never-dropped settle check. Registered for the drivers with the deepest race history — ToupTek camera, AFW filter wheel, and thermal switch run hardware-free over the fake SDK seam (issue #104), wrapped in a new thread-safe `LockedToupTekSDK` decorator so TSan findings point at driver code rather than the deliberately unhardened test fake; ZWO EFW and Player One Phoenix storm the failure path on hardware-free hosts (full path with a wheel attached). Wired into `scripts/ci_preflight.sh` behind `RUN_TSAN=1` (mirroring `RUN_SANITIZERS=1`) with a suppressions file that mutes only the uninstrumented proprietary vendor blobs. The CI job fails loudly if Catch2 is missing instead of green-lighting an empty suite.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AlpacaBridge is a growing suite of native ASCOM Alpaca drivers for Linux, every one ConformU-verified, that turns any single-board computer into a gear-control server. There's no ASCOM Platform to install and no vendor COM drivers to chase down. Just flash it onto a Raspberry Pi, iOptron iMate, ToupTek StellaVita, or ZWO ASIAIR, connect your equipment once, and control gear like cameras, mounts, focusers, filter wheels, rotators, cover calibrators, switches, and weather stations over the network from any Alpaca-compatible app, including N.I.N.A., Sequence Generator Pro, and SharpCap.
 
-#### [2.2.0] - 2026-07-01 &middot; [Changelog](CHANGELOG.md)
+#### [3.0.0] - 2026-07-06 &middot; [Changelog](CHANGELOG.md)
 
 ## Features
 


### PR DESCRIPTION
Cuts the 3.0.0 release: dates the `## [3.0.0]` CHANGELOG heading 2026-07-06 and updates the README version badge (stale at 2.2.0 since PR #99) to match. `VERSION` already reads 3.0.0.

First tagged release of AlpacaBridge. Major version per the ToupTek `cameraIndex` enumeration break (accessories no longer consume camera slots — see the migration note in the CHANGELOG). Highlights since PR #99: AsyncConnectable across all 26 drivers (#100), TSan CI + stress harness (#101), config round-trip tests (#102/#114), ToupTek AFW + thermal switch drivers, AGPL-3.0 relicense (#118), and the camera close-order/race audit (#116/#119/#121).

After merge: tag `v3.0.0` on the merge commit and publish the GitHub Release.

## Test plan
- [x] Local CI pre-flight green: unicode scan, `run_all_tests.sh` vendors OFF + ON (265/265 tests); format/tidy/cppcheck skipped (no C/C++ changes)
- [x] `scripts/changelog_to_deb.py` generates a clean `alpacabridge (3.0.0) stable` stanza from the dated heading (`dpkg-parsechangelog` validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)