### PR TITLE
Give the review bot read-only code access for large-PR reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,4 +64,4 @@ jobs:
             Do not submit the review text as a chat message.
           claude_args: |
             --model sonnet
-            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"


### PR DESCRIPTION
## Summary
- The Claude Code Review runs on PR #124 finished "successfully" twice without posting their review: with `--allowedTools` limited to `gh pr comment/diff/view`, the reviewer burned its turns on denied attempts to read the checked-out sources (12 then 20 permission denials) and never landed the `gh pr comment` call.
- Adds read-only inspection tools (`Read`, `Grep`, `Glob`, `git log/diff/show`) to the reviewer's allowlist; write access remains limited to `gh pr comment`.
- Shipped as its own PR because the action's anti-tampering validation skips any review run whose workflow file differs from the default branch — the change is inert until merged, so it can't ride on the PR that needs it (it was tried on #124 and reverted there).

## Test plan
- [x] zizmor clean locally (same pinned 1.25.2 as CI)
- [ ] After merge: re-run the review on PR #124 and confirm the comment posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)