### PR TITLE
Make the review bot post via --body-file to avoid substitution denials

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -60,8 +60,13 @@ jobs:
               "✅ Approved" if no significant issues, or
               "⚠️ Issues found" if there are things to address.
 
-            Post your review as a SINGLE top-level comment using `gh pr comment`.
+            Post your review as a SINGLE top-level comment. To post it: first
+            write the full review text to /tmp/review.md with the Write tool,
+            then run exactly `gh pr comment <PR NUMBER> --body-file /tmp/review.md`.
+            Do NOT use --body with command substitution ($(...)/backticks/heredocs)
+            — the permission rules reject any command containing substitution, and
+            the review will silently fail to post.
             Do not submit the review text as a chat message.
           claude_args: |
             --model sonnet
-            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,Write,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"


### PR DESCRIPTION
## Summary
- Even after #125 (read access), review runs on PR #124 finished with ~20 permission denials and never posted: `Bash(gh pr comment:*)` rejects any command containing command substitution, and a long multiline review posted via `--body "$(cat <<'EOF' ...)"` is exactly that. Short plain `--body` reviews posted fine — hence the intermittent look (2 of 6 runs posted).
- Allows the `Write` tool and instructs the reviewer to compose the review in `/tmp/review.md` and post with `gh pr comment --body-file` — no substitution anywhere in the command.
- Separate PR for the same reason as #125: the action skips runs whose workflow file differs from the default branch.

## Test plan
- [x] zizmor clean locally (pinned 1.25.2, matches CI)
- [ ] After merge: sync PR #124 and confirm the review posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)