### PR TITLE
Fix #127: enforce HTTP header-size cap on the terminating recv

### DIFF
--- a/AlpacaHTTP/src/http/server.cpp
+++ b/AlpacaHTTP/src/http/server.cpp
@@ -325,12 +325,18 @@ bool read_request(util::SocketHandle socket_fd, std::string& raw_request) {
         }
         raw_request.append(buffer, static_cast<std::size_t>(bytes_read));
         header_end = raw_request.find("\r\n\r\n");
-        if (header_end != std::string::npos) {
-            break;
-        }
-        if (raw_request.size() > kMaxHeaderBytes) {
+        // Enforce the header-size cap on every iteration, including the one that
+        // finds the terminator — otherwise the terminating chunk could push the
+        // header block up to one recv buffer past the cap unchecked. When the
+        // terminator is found, only the bytes up to it count as headers (the
+        // rest is body); before that, the whole buffer is header so far.
+        const std::size_t header_bytes = (header_end != std::string::npos) ? header_end : raw_request.size();
+        if (header_bytes > kMaxHeaderBytes) {
             send_error(socket_fd, 431, "Request Header Fields Too Large", "Request headers too large");
             return false;
+        }
+        if (header_end != std::string::npos) {
+            break;
         }
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to the #124 review. `AlpacaHTTP/src/http/server.cpp` `read_request()` only checked `kMaxHeaderBytes` on iterations that had not yet found the `\r\n\r\n` terminator, so the recv chunk containing the terminator was appended and broke the loop *before* the size check — the header block could exceed the 64 KB cap by up to one recv buffer (~8 KB).
- The check now runs on every iteration. When the terminator is found, only the bytes up to it count as headers (the rest is body); before that, the whole accumulated buffer is header-so-far. The cap is now enforced exactly, still returning `431`.

Closes #127.

## Test plan
- [x] `run_all_tests.sh` — vendors OFF + ON, 273 + 278 tests pass
- [x] clang-format + clang-tidy clean on the changed lines
- Bounded-only correctness fix (no exploitable change); existing routing tests exercise `read_request` indirectly via the server path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)