### PR TITLE
CI: CodeQL scanning + review-comment assertion (DevSecOps parity with openastro-ara)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,3 +70,38 @@ jobs:
           claude_args: |
             --model sonnet
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob,Write,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+
+      # Ported from openastro-ara #862/#863: the action exits 0 even when the
+      # agent never manages to post its comment, so a green check could exist
+      # with no review anywhere. The review BODY is the artifact — a run that
+      # produced no fresh bot comment must fail the check.
+      - name: Assert the review comment posted
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The action refuses to run on a PR that modifies this very workflow
+          # (it requires the file to match the default branch). That skip is
+          # loud in the log and only possible on a workflow-editing PR, which
+          # the maintainer reviews by eye — exempt it so such PRs aren't
+          # permanently red, while every normal PR still requires a comment.
+          if gh pr diff "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" --name-only \
+              | grep -qx ".github/workflows/claude-review.yml"; then
+            echo "::warning::This PR modifies the review workflow — the action skips itself on such PRs; passing without a review comment. Review it by eye."
+            exit 0
+          fi
+          # Only the BOT's comments count, and only ones touched during THIS
+          # run — a human writing "Approved" in discussion, or a sticky
+          # comment left over from a previous commit's review, must not
+          # satisfy the gate.
+          started="$(gh run view "$GITHUB_RUN_ID" --repo "${{ github.repository }}" --json createdAt --jq .createdAt)"
+          if gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate \
+              | jq -r --arg since "$started" \
+              '.[] | select(.user.login | test("^(claude|github-actions)(\\[bot\\])?$")) | select(.updated_at >= $since) | .body' \
+              | grep -qE "Approved|Issues found"; then
+            echo "Review comment found."
+          else
+            echo "::error::The review agent finished without posting its comment — failing rather than green-lighting a review that does not exist."
+            exit 1
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# CodeQL security scanning for the C/C++ AlpacaBridge sources.
+#
+# Runs on x86_64 (ubuntu-latest) — the lone exception to this repo's
+# arm64-only fleet (see ci.yml's header): the CodeQL CLI has no arm64 build.
+# That works because `build-mode: none` extracts directly from source without
+# configuring or compiling the project, so the CMake arm64 hard-fail never
+# triggers. Results land in Security → Code scanning; this workflow does not
+# gate merges.
+#
+# Actions are pinned to immutable commit SHAs per the repo's zizmor policy.
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Weekly catch-all so advisories published after a quiet period still surface.
+    - cron: "41 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (c-cpp)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload results to code scanning
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          languages: c-cpp
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          category: "/language:c-cpp"


### PR DESCRIPTION
## Summary

Closes the two workflow-level DevSecOps gaps found in a cross-repo audit against openastro-ara:

- **CodeQL for C/C++**: ci.yml's header already reserved CodeQL a workflow of its own (its CLI has no arm64 build). This adds it on \`ubuntu-latest\` with \`build-mode: none\`, which extracts from source without configuring the project — so the repo's arm64-only CMake hard-fail never triggers. Push/PR/weekly-cron triggers; results land in Security → Code scanning; not a merge gate. Actions SHA-pinned per the zizmor policy.
- **Review-comment assertion** (port of openastro-ara #862/#863): the claude-review action exits 0 even when its agent fails to post the review comment, so a green \`review\` check could exist with no review anywhere — observed live on openastro-ara #861. The new step fails the job unless a bot comment carrying the sign-off wording was created/updated after this run started, with a loud exemption for PRs that modify the review workflow itself (the action skips itself on those).

Also applied outside this PR (repo settings): openastro-ara now has secret scanning + push protection enabled, and this repo's \`main\` branch protection is now strict (branches must be up to date before merge).

## Test plan

- Both YAMLs validate; the zizmor job in CI audits them.
- The claude-review change exercises its own exemption path on this PR; the assertion proves out on the next normal PR. CodeQL's first run happens on this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)