### PR TITLE
ci: label-gated review bot for fork PRs (safe-to-review)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,15 @@
 name: Claude Code Review
 
+# pull_request_target (not pull_request) so repository secrets are available
+# to fork PRs — but ONLY once a maintainer applies the `safe-to-review` label
+# (see the job-level `if`). The workflow definition always comes from the
+# default branch under this trigger, so a fork PR cannot alter the bot's
+# prompt/tools; the residual risk is the agent READING hostile PR content
+# (prompt injection into the review comment), bounded by the locked-down
+# allowedTools below. The maintainer's label click is the trust decision.
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request_target:  # zizmor: ignore[dangerous-triggers] -- label-gated; see comment above
+    types: [opened, synchronize, labeled]
 
 # Cancel an in-progress review if a newer commit is pushed to the same PR,
 # so rapid pushes don't stack up redundant reviews (saves usage).
@@ -12,14 +19,18 @@ concurrency:
 
 jobs:
   review:
-    # CLAUDE_CODE_OAUTH_TOKEN is a repository secret, which GitHub withholds from
-    # Dependabot-triggered and fork-triggered pull_request runs as a security
-    # boundary. Without the token the claude-code-action can't authenticate and
-    # the job fails spuriously. Skip the review in those cases (it is not a
-    # required status check; a maintainer reviews bot and fork PRs by hand).
+    # Same-repo branches review automatically on every push. Fork PRs review
+    # only while a maintainer has applied the `safe-to-review` label: the
+    # `labeled` trigger fires the first review the moment the label lands, and
+    # `synchronize` keeps reviewing later pushes for as long as the label stays
+    # on (remove it to stop the bot). Dependabot PRs are skipped entirely (its
+    # bumps are reviewed by eye; no point spending bot runs on lockstep bumps).
     if: >-
       github.actor != 'dependabot[bot]'
-      && github.event.pull_request.head.repo.full_name == github.repository
+      && (
+        github.event.pull_request.head.repo.full_name == github.repository
+        || contains(github.event.pull_request.labels.*.name, 'safe-to-review')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
+          # pull_request_target checks out the BASE branch by default; the bot
+          # must review the PR's actual code. Explicit head SHA (not the merge
+          # ref) so the review matches exactly what the author pushed.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           persist-credentials: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,17 @@ Two of our worst deadlocks are documented later, not in the checklist above — 
 narrow-`firmware_mutex_` rule (under "Device firmware / SDK version") before touching
 any connect/disconnect path or a getter that takes the coarse driver `mutex_`.
 
+### Review bot on fork PRs (`safe-to-review` label)
+
+The Claude review bot (`.github/workflows/claude-review.yml`) runs automatically on
+every push to a same-repo PR branch. Fork PRs are gated: the bot runs only while a
+maintainer has applied the **`safe-to-review`** label — applying it triggers the
+first review immediately, later pushes keep reviewing while the label stays on, and
+removing the label stops the bot. The label is the maintainer's trust decision: the
+workflow runs with `pull_request_target` (definition always taken from `main`, so a
+fork can't alter the bot's prompt/tools), and the residual risk of the bot *reading*
+hostile PR content is accepted per-PR by whoever applies the label.
+
 ### When fixing a review finding (avoid the regression treadmill)
 
 Across our driver PRs, most review rounds were spent on **regressions introduced by


### PR DESCRIPTION
## Summary
- Switches `claude-review.yml` from `pull_request` to `pull_request_target` so the `CLAUDE_CODE_OAUTH_TOKEN` secret reaches fork PRs — gated on a maintainer applying the new `safe-to-review` label (already created in the repo).
- Applying the label triggers the first review immediately (`labeled` event); later pushes keep reviewing while the label stays on (`synchronize`); removing the label stops the bot. Same-repo PRs review automatically on every push, unchanged.
- Checkout now pins `ref: ${{ github.event.pull_request.head.sha }}` — under `pull_request_target` the default checkout is the base branch, which would have the bot reviewing the wrong code.
- AGENTS.md documents the workflow and the trust model.

## Security model
- The workflow definition always comes from `main` under `pull_request_target`, so a fork PR cannot alter the bot's prompt or allowed tools.
- Residual risk is the agent *reading* hostile PR content (prompt injection into the review comment), bounded by the locked-down `allowedTools` (no arbitrary bash) — and accepted per-PR by the maintainer's label click. Only users with triage+ permission can apply labels.
- `zizmor --offline` passes with an inline justified `ignore[dangerous-triggers]`.

## Test plan
- [x] `zizmor --offline .github/workflows/` — no findings
- [ ] After merge: apply `safe-to-review` to PRs #142 and #143 and confirm the bot posts reviews

Note: this PR modifies the review workflow itself, so per the existing assert-step exemption the bot will not review it — review by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)