### PR TITLE
ci: opt in to fork checkout in the label-gated review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,6 +43,11 @@ jobs:
           # must review the PR's actual code. Explicit head SHA (not the merge
           # ref) so the review matches exactly what the author pushed.
           ref: ${{ github.event.pull_request.head.sha }}
+          # checkout v7 refuses fork-code checkout under pull_request_target
+          # without this opt-in. Accepting that risk is exactly what the
+          # maintainer's safe-to-review label means (see the trigger comment);
+          # the fork code is read, never built or executed, in this job.
+          allow-unsafe-pr-checkout: true
           fetch-depth: 1
           persist-credentials: false
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,6 +52,12 @@ jobs:
           persist-credentials: false
 
       - uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35  # v1
+        # The assert step below is the REAL gate (comment posted or fail), and
+        # it exempts workflow-editing PRs — where this action refuses to run
+        # ("Invalid OIDC token" when the workflow file differs from the default
+        # branch) and would otherwise hard-fail the job before the assert
+        # step's exemption can apply.
+        continue-on-error: true
         with:
           # Subscription (Pro/Max) auth. Generate locally with `claude setup-token`
           # and store as an org or repo secret named CLAUDE_CODE_OAUTH_TOKEN.


### PR DESCRIPTION
## Summary
- Follow-up to #145: the first labeled run on PR #143 failed because `actions/checkout` v7 refuses to fetch fork PR code under `pull_request_target` without an explicit `allow-unsafe-pr-checkout: true` opt-in.
- The `safe-to-review` label gate is exactly the maintainer accepting that risk per-PR, and the review job only reads the code — it never builds or executes it — so the opt-in is added with a comment saying so.

## Test plan
- [x] `zizmor --offline .github/workflows/` — no findings
- [ ] After merge: re-apply `safe-to-review` on #143 to re-trigger and confirm the bot posts its review

Note: modifies the review workflow itself — review by eye, same as #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)