### PR TITLE
ci: pass an explicit github_token to the review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,6 +62,13 @@ jobs:
           # Subscription (Pro/Max) auth. Generate locally with `claude setup-token`
           # and store as an org or repo secret named CLAUDE_CODE_OAUTH_TOKEN.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit token so the action skips its OIDC -> GitHub App token
+          # exchange: Anthropic's exchange endpoint 401s pull_request_target
+          # runs ("Invalid OIDC token"), which this workflow needs for
+          # label-gated fork reviews. The workflow's own permissions block
+          # grants this token pull-requests: write; the review comment posts
+          # as github-actions[bot], which the assert step already accepts.
+          github_token: ${{ github.token }}
           # Keep the whole review in ONE top-level comment that updates in place,
           # instead of posting a new comment on every push.
           use_sticky_comment: true


### PR DESCRIPTION
## Summary
- Third and hopefully final piece of the label-gated fork review work (#145, #146): PR #143's labeled run got past checkout but died in the claude-code-action's OIDC → GitHub App token exchange (`401 Unauthorized - Invalid OIDC token`) — the exchange endpoint doesn't accept `pull_request_target` runs.
- Passing `github_token: ${{ github.token }}` makes the action skip the exchange entirely and use the workflow's own token (already granted `pull-requests: write`). The review comment will post as `github-actions[bot]`, which the assert step's author regex already accepts.

## Test plan
- [x] `zizmor --offline .github/workflows/` — no findings
- [ ] After merge: cycle `safe-to-review` on #143 and confirm the bot posts its review

Note: modifies the review workflow itself — the review check on THIS PR will show the known workflow-editing behavior; review by eye like #145/#146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)