### PR TITLE
ci: allow Knetus56 to trigger the label-gated fork review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -86,7 +86,7 @@ jobs:
           # trusted fork contributors here (never '*') — the label remains
           # the per-PR trust decision, this list is the per-person one.
           # Requires the explicit github_token above.
-          allowed_non_write_users: "htly9981"
+          allowed_non_write_users: "htly9981,Knetus56"
           # Keep the whole review in ONE top-level comment that updates in place,
           # instead of posting a new comment on every push.
           use_sticky_comment: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,12 @@ workflow runs with `pull_request_target` (definition always taken from `main`, s
 fork can't alter the bot's prompt/tools), and the residual risk of the bot *reading*
 hostile PR content is accepted per-PR by whoever applies the label.
 
+Trusted fork contributors are also listed in the workflow's `allowed_non_write_users`
+input (specific usernames, never `*`): without it, a fork contributor's own push to a
+labeled PR fails the review job in seconds ("Actor does not have write permissions").
+To onboard a new fork contributor, add their username to that list — do **not** grant
+them collaborator/write access; the `safe-to-review` label stays the per-PR trust gate.
+
 ### When fixing a review finding (avoid the regression treadmill)
 
 Across our driver PRs, most review rounds were spent on **regressions introduced by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
+## [3.1.3] - UNRELEASED
+
+### Changed
+- **CI: Knetus56 added to the review workflow's trusted fork contributors** (.github/workflows/claude-review.yml): added to `allowed_non_write_users` so their own pushes to a `safe-to-review`-labeled fork PR no longer fail the review job; the label remains the maintainer's per-PR trust gate, and AGENTS.md now documents this list as the onboarding path (instead of granting write access).
+
 ## [3.1.2] - 2026-07-31
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Adds Knetus56 to `allowed_non_write_users` in the claude-review workflow, following the established fork-contributor onboarding process (same as htly9981, commit 17f6e21).
- No write access granted — the `safe-to-review` label remains the maintainer's per-PR trust gate.

## Changes
- **CI** (.github/workflows/claude-review.yml): `allowed_non_write_users` now `"htly9981,Knetus56"`, so their own pushes to a labeled fork PR no longer fail the review job ("Actor does not have write permissions").
- **Documentation**: AGENTS.md documents this list as the fork-contributor onboarding path; CHANGELOG entry added under `[3.1.3] - UNRELEASED`.

## Test plan
- [x] Local CI pre-flight green (unicode scan, build+test vendors OFF/ON, zizmor; format/tidy/cppcheck/shellcheck/JS skipped — no matching changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)