### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 AlpacaBridge is a workspace that combines [AlpacaCore](AlpacaCore/README.md) and [AlpacaHTTP](AlpacaHTTP/README.md).
 
-## [3.2.0] - UNRELEASED
+## [3.2.0] - 2026-08-05
 
 ### Added
 - **Gemini Astro Automatic FlatPanel v2 Driver** (AlpacaCore): CoverCalibrator driver for the second Gemini flat panel model — adds a real motorized cover on top of the light/brightness controls shared with the Astro Flat Panel Cover Lite. Implemented from INDI's open-source `GeminiFlatpanelRev2Adapter` (`indilib/indi`), since no vendor docs or hardware were available at the outset. Selected via a `flatPanelModel` config field (`"lite"`/`"v2"`) on the same `gemini`+`covercalibrator` router slot as the Lite driver; shares port auto-detection with it. `OpenCover`/`CloseCover` block the wire for up to 30s waiting for the hardware's exact completion reply (`*OOpened#`/`*CClosed#`) and run on a background thread so the ASCOM async initiator returns immediately. `HaltCover` has no hardware equivalent on this revision — it only stops the driver from *reporting* movement, since the in-flight wire command can't be interrupted.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 AlpacaBridge is a growing suite of native ASCOM Alpaca drivers for Linux, every one ConformU-verified, that turns any single-board computer into a gear-control server. There's no ASCOM Platform to install and no vendor COM drivers to chase down. Just flash it onto a Raspberry Pi, iOptron iMate, ToupTek StellaVita, or ZWO ASIAIR, connect your equipment once, and control gear like cameras, mounts, focusers, filter wheels, rotators, cover calibrators, switches, and weather stations over the network from any Alpaca-compatible app, including N.I.N.A., Sequence Generator Pro, and SharpCap.
 
-#### [3.1.2] - 2026-07-31 &middot; [Changelog](CHANGELOG.md)
+#### [3.2.0] - 2026-08-05 &middot; [Changelog](CHANGELOG.md)
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Finalize the 3.2.0 release: date the CHANGELOG entry and update the README version badge to 3.2.0 (2026-08-05)
- `VERSION` was already bumped to 3.2.0 in PR #174; this aligns README and CHANGELOG with it

## Changes
- **Documentation**: README version badge → 3.2.0 - 2026-08-05; CHANGELOG `[3.2.0]` heading dated 2026-08-05

## Test plan
- [x] Local CI pre-flight green (docs-only change: format + unicode gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)