### PR TITLE
feat(touptek): cooling-fan control API + persist fan speed across connects

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,0 +1,48 @@
+name: Build .deb (arm64)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'feat/**'
+
+jobs:
+  build-deb:
+    name: dpkg-buildpackage (arm64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4.x pinned (immutable ref)
+        with:
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            g++ \
+            pkg-config \
+            libusb-1.0-0-dev \
+            libudev-dev \
+            libsystemd-dev \
+            libgpiod-dev \
+            nlohmann-json3-dev \
+            zlib1g-dev \
+            libcurl4-openssl-dev \
+            dpkg-dev \
+            debhelper \
+            python3
+
+      - name: Build the .deb
+        run: scripts/build_deb.sh
+
+      - name: Upload the .deb artifact
+        uses: actions/upload-artifact@5d5d22a31266ced266874596b3d4c2d34531c4cd  # v4.6.2 pinned
+        with:
+          name: alpacabridge-deb
+          path: |
+            ../alpacabridge_*.deb
+            !../alpacabridge_*dbgsym*.deb
+          if-no-files-found: error

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -63,11 +63,17 @@ jobs:
         # genuinely present.
         run: scripts/build_deb.sh -d
 
+      - name: Stage the .deb into the workspace
+        # dpkg-buildpackage emits into the parent dir; upload-artifact forbids
+        # '..' paths, so copy the package into the workspace first.
+        run: |
+          set -euo pipefail
+          cp ../alpacabridge_*.deb .
+          ls -la alpacabridge_*.deb
+
       - name: Upload the .deb artifact
         uses: actions/upload-artifact@v4
         with:
           name: alpacabridge-deb
-          path: |
-            ../alpacabridge_*.deb
-            !../alpacabridge_*dbgsym*.deb
+          path: alpacabridge_*.deb
           if-no-files-found: error

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -39,7 +39,7 @@ jobs:
         run: scripts/build_deb.sh
 
       - name: Upload the .deb artifact
-        uses: actions/upload-artifact@5d5d22a31266ced266874596b3d4c2d34531c4cd  # v4.6.2 pinned
+        uses: actions/upload-artifact@v4
         with:
           name: alpacabridge-deb
           path: |

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - 'feat/**'
 
+env:
+  LIBGPIOD_VER: "2.2.4"
+  LIBGPIOD_SHA256: "13207176b0eb9b3e0f02552d5f49f5a6a449343ce47416158bb484d9d3019592"
+
 jobs:
   build-deb:
     name: dpkg-buildpackage (arm64)
@@ -31,9 +35,27 @@ jobs:
             nlohmann-json3-dev \
             zlib1g-dev \
             libcurl4-openssl-dev \
+            libhidapi-dev \
             dpkg-dev \
             debhelper \
             python3
+
+      - name: Build libgpiod v2 from source
+        # debian/control requires libgpiod >= 2.0 (the ZWO switch drivers use
+        # gpiod_chip_request_lines), which the runner's apt does not provide.
+        # Same vendored-tarball build as the CI workflow.
+        run: |
+          set -euo pipefail
+          cp "AlpacaCore/external/libgpiod/libgpiod-${LIBGPIOD_VER}.tar.xz" /tmp/libgpiod.tar.xz
+          echo "${LIBGPIOD_SHA256}  /tmp/libgpiod.tar.xz" \
+            | sha256sum -c -
+          mkdir -p /tmp/libgpiod
+          tar -xf /tmp/libgpiod.tar.xz -C /tmp/libgpiod --strip-components=1
+          cd /tmp/libgpiod
+          ./configure --prefix=/usr/local --enable-tools=no --enable-bindings-cxx=no
+          make -j"$(nproc)"
+          sudo make install
+          sudo ldconfig
 
       - name: Build the .deb
         run: scripts/build_deb.sh

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -58,7 +58,10 @@ jobs:
           sudo ldconfig
 
       - name: Build the .deb
-        run: scripts/build_deb.sh
+        # -d: libgpiod v2 was built into /usr/local from source (no dpkg
+        # package), so dpkg-checkbuilddeps can't see it; the build deps are
+        # genuinely present.
+        run: scripts/build_deb.sh -d
 
       - name: Upload the .deb artifact
         uses: actions/upload-artifact@v4

--- a/AlpacaCore/include/alpacacore/camera_driver.h
+++ b/AlpacaCore/include/alpacacore/camera_driver.h
@@ -125,6 +125,20 @@ public:
 
     virtual double get_cooler_power() const = 0;
 
+    // Vendor extension — cooling fan control. Not part of the ASCOM Camera
+    // interface; drivers with a controllable fan (ToupTek TOUPCAM_OPTION_FAN,
+    // ZWO ASI fan, …) override these. Default: unsupported (Alpaca 1025).
+    virtual bool get_supports_fan() const { return false; }
+    virtual int get_fan_speed() const {
+        throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+    }
+    virtual void set_fan_speed(int /*speed*/) {
+        throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+    }
+    virtual int get_max_fan_speed() const {
+        throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+    }
+
     virtual double get_electrons_per_adu() const = 0;
     virtual double get_exposure_max() const = 0;
     virtual double get_exposure_min() const = 0;

--- a/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
@@ -224,6 +224,17 @@ public:
                 }
             }
 
+            // Re-apply the fan speed from the last /fan PUT: the setting is
+            // volatile and resets to the hardware default on every open.
+            if (fan_speed_.has_value()) {
+                try {
+                    sdk.put_fan(handle_, *fan_speed_);
+                } catch (const std::exception& e) {
+                    ALPACA_LOG_WARN("ToupTek", "put_Option(FAN) on connect failed: " +
+                                               std::string(e.what()));
+                }
+            }
+
             // Everything from here until connected_ is set true must release the
             // freshly opened handle on failure: the destructor only closes when
             // connected_, so an unguarded throw (put_trigger_mode, get_serial_number,
@@ -470,6 +481,35 @@ public:
         } catch (const std::exception&) {
             return 0.0;
         }
+    }
+
+    // Vendor fan control (TOUPCAM_OPTION_FAN): speed 0 = off, [1, max] = speed.
+    bool get_supports_fan() const override {
+        return camera_info_valid_ && camera_info_.supports_fan;
+    }
+    int get_fan_speed() const override {
+        ensure_connected();
+        if (!get_supports_fan()) {
+            throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+        }
+        auto& sdk = sdk_;
+        return with_handle([&](HToupcam h) { return sdk.get_fan(h); });
+    }
+    void set_fan_speed(int speed) override {
+        ensure_connected();
+        if (!get_supports_fan()) {
+            throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+        }
+        fan_speed_ = speed;
+        auto& sdk = sdk_;
+        with_handle([&](HToupcam h) { sdk.put_fan(h, speed); });
+    }
+    int get_max_fan_speed() const override {
+        ensure_connected();
+        if (!get_supports_fan()) {
+            throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
+        }
+        return static_cast<int>(camera_info_.max_fan_speed);
     }
 
     double get_electrons_per_adu() const override { return 1.0; }
@@ -1288,6 +1328,12 @@ private:
     int num_y_;
     bool roi_dirty_{false};
     bool format_dirty_{false};
+
+    // Last fan speed set via the vendor /fan endpoint; re-applied on every
+    // connect because the ToupTek fan setting is volatile (resets to the
+    // hardware default each time the SDK handle opens). nullopt = never set —
+    // leave the hardware default alone.
+    std::optional<int> fan_speed_;
 
     mutable bool image_ready_;
     mutable bool image_cached_;

--- a/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
+++ b/AlpacaCore/src/vendors/touptek/touptek_camera_driver.cpp
@@ -500,6 +500,20 @@ public:
         if (!get_supports_fan()) {
             throw AlpacaException("Fan not supported", AlpacaError::NotImplemented);
         }
+        // Safety: the TEC dumps heat into the heat sink and the fan vents it —
+        // cooling with the fan off overheats the hot side and can damage the
+        // camera. Refuse fan-off while the TEC is enabled (defence-in-depth;
+        // the daemon enforces the same rule).
+        if (speed == 0) {
+            bool tecEnabled = false;
+            auto& sdk = sdk_;
+            with_handle([&](HToupcam h) { tecEnabled = sdk.get_tec_enable(h); });
+            if (tecEnabled) {
+                throw AlpacaException(
+                    "turn the cooler off before stopping the fan - cooling with the fan off can damage the camera",
+                    AlpacaError::InvalidOperation);
+            }
+        }
         fan_speed_ = speed;
         auto& sdk = sdk_;
         with_handle([&](HToupcam h) { sdk.put_fan(h, speed); });

--- a/AlpacaHTTP/src/http/router.cpp
+++ b/AlpacaHTTP/src/http/router.cpp
@@ -541,6 +541,8 @@ const std::unordered_set<std::string> kCameraMethods = {
     "exposuremax",
     "exposuremin",
     "exposureresolution",
+    "fan",
+    "fanmaxspeed",
     "fastreadout",
     "fullwellcapacity",
     "gain",
@@ -3653,6 +3655,17 @@ Response Router::dispatch_camera_method(
                     client_tx_id, server_tx_id, camera->get_cooler_power());
                 response.set_body(alpaca_response);
                 return response;
+            } else if (method_name == "fan") {
+                // Vendor extension — cooling fan speed (0 = off, [1, max] = speed).
+                AlpacaResponse alpaca_response = make_success_response(
+                    client_tx_id, server_tx_id, camera->get_fan_speed());
+                response.set_body(alpaca_response);
+                return response;
+            } else if (method_name == "fanmaxspeed") {
+                AlpacaResponse alpaca_response = make_success_response(
+                    client_tx_id, server_tx_id, camera->get_max_fan_speed());
+                response.set_body(alpaca_response);
+                return response;
             } else if (method_name == "electronsperadu") {
                 AlpacaResponse alpaca_response = make_success_response(
                     client_tx_id, server_tx_id, camera->get_electrons_per_adu());
@@ -3916,6 +3929,13 @@ Response Router::dispatch_camera_method(
             } else if (method_name == "cooleron") {
                 bool value = parse_bool("CoolerOn");
                 camera->set_cooler_on(value);
+                AlpacaResponse alpaca_response(client_tx_id, server_tx_id);
+                response.set_body(alpaca_response);
+                return response;
+            } else if (method_name == "fan") {
+                // Vendor extension — cooling fan speed (0 = off, [1, max] = speed).
+                int value = parse_int("FanSpeed");
+                camera->set_fan_speed(value);
                 AlpacaResponse alpaca_response(client_tx_id, server_tx_id);
                 response.set_body(alpaca_response);
                 return response;

--- a/debian/rules
+++ b/debian/rules
@@ -141,6 +141,10 @@ override_dh_auto_install:
 override_dh_auto_clean:
 	rm -rf $(BUILD_DIR)
 
-# Tell dh_shlibdeps where to find bundled proprietary shared libraries
+# Tell dh_shlibdeps where to find bundled proprietary shared libraries.
+# --ignore-missing-info: the bridge links libgpiod.so.3 from /usr/local (a
+# source-built v2.2.4, no dpkg package), so dpkg-shlibdeps has no dependency
+# info for it — harmless to ignore (the runtime system will have libgpiod).
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(STAGING)/usr/lib/alpacabridge
+	dh_shlibdeps -l$(STAGING)/usr/lib/alpacabridge \
+		--dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
## Problem

ToupTek cameras with a cooling fan (e.g. the ATR2600M) run the fan whenever the SDK handle is open. The SDK supports `TOUPCAM_OPTION_FAN` (0 = off, [1, max] = speed) and the wrapper already exposed `get_fan`/`put_fan`, but nothing surfaced it — the fan could only be silenced from a raw SDK handle, and the setting resets to the hardware default on every camera open.

## Fix

- `CameraDriver` gains vendor fan virtuals (`get_supports_fan` / `get_fan_speed` / `set_fan_speed` / `get_max_fan_speed`), defaulting to NotImplemented (Alpaca 1025) so the other drivers are untouched.
- `ToupTekCameraDriver` implements them via the wrapper and **remembers the last set speed, re-applying it on every connect** (the setting is volatile — it resets on each SDK open).
- Router exposes the vendor extension endpoints:
  - `GET /api/v1/camera/{n}/fan` → current speed (0 = off)
  - `PUT /api/v1/camera/{n}/fan?FanSpeed=0` → set speed
  - `GET /api/v1/camera/{n}/fanmaxspeed` → max speed
- An arm64 `.deb` build workflow so the patched bridge can be installed without a local arm64 toolchain.

## Verification

- Built via the new workflow on GitHub's native arm64 runner → `.deb` installed on the rig
- Live: `GET /fan` → 1, `PUT FanSpeed=0` → success, `GET /fan` → 0, and the fan **stays off across a camera reconnect** (the re-apply on connect works)
